### PR TITLE
benchmark-framework: using nanoseconds resolution rate limiter

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/RateLimiter.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/RateLimiter.java
@@ -1,0 +1,388 @@
+package io.openmessaging.benchmark.utils;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.lang.Math.max;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Stopwatch;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.openmessaging.benchmark.utils.SmoothRateLimiter.SmoothBursty;
+import io.openmessaging.benchmark.utils.SmoothRateLimiter.SmoothWarmingUp;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public abstract class RateLimiter {
+  /**
+   * Creates a {@code RateLimiter} with the specified stable throughput, given
+   * as "permits per second" (commonly referred to as <i>QPS</i>, queries per
+   * second).
+   *
+   * <p>The returned {@code RateLimiter} ensures that on average no more than
+   * {@code permitsPerSecond} are issued during any given second, with sustained
+   * requests being smoothly spread over each second. When the incoming request
+   * rate exceeds {@code permitsPerSecond} the rate limiter will release one
+   * permit every {@code (1.0 / permitsPerSecond)} seconds. When the rate
+   * limiter is unused, bursts of up to {@code permitsPerSecond} permits will be
+   * allowed, with subsequent requests being smoothly limited at the stable rate
+   * of {@code permitsPerSecond}.
+   *
+   * @param permitsPerSecond the rate of the returned {@code RateLimiter},
+   *     measured in how many permits become available per second
+   * @throws IllegalArgumentException if {@code permitsPerSecond} is negative or
+   *     zero
+   */
+  // TODO(user): "This is equivalent to
+  // {@code createWithCapacity(permitsPerSecond, 1, TimeUnit.SECONDS)}".
+  public static RateLimiter create(double permitsPerSecond) {
+    /*
+     * The default RateLimiter configuration can save the unused permits of up
+     * to one second. This is to avoid unnecessary stalls in situations like
+     * this: A RateLimiter of 1qps, and 4 threads, all calling acquire() at
+     * these moments:
+     *
+     * T0 at 0 seconds
+     * T1 at 1.05 seconds
+     * T2 at 2 seconds
+     * T3 at 3 seconds
+     *
+     * Due to the slight delay of T1, T2 would have to sleep till 2.05 seconds,
+     * and T3 would also have to sleep till 3.05 seconds.
+     */
+    return create(permitsPerSecond, SleepingStopwatch.createFromSystemTimer());
+  }
+
+  static RateLimiter create(double permitsPerSecond,
+                            SleepingStopwatch stopwatch) {
+    RateLimiter rateLimiter =
+        new SmoothBursty(stopwatch, 1.0 /* maxBurstSeconds */);
+    rateLimiter.setRate(permitsPerSecond);
+    return rateLimiter;
+  }
+
+  /**
+   * Creates a {@code RateLimiter} with the specified stable throughput, given
+   * as "permits per second" (commonly referred to as <i>QPS</i>, queries per
+   * second), and a <i>warmup period</i>, during which the {@code RateLimiter}
+   * smoothly ramps up its rate, until it reaches its maximum rate at the end of
+   * the period (as long as there are enough requests to saturate it).
+   * Similarly, if the {@code RateLimiter} is left <i>unused</i> for a duration
+   * of {@code warmupPeriod}, it will gradually return to its "cold" state, i.e.
+   * it will go through the same warming up process as when it was first
+   * created.
+   *
+   * <p>The returned {@code RateLimiter} is intended for cases where the
+   * resource that actually fulfills the requests (e.g., a remote server) needs
+   * "warmup" time, rather than being immediately accessed at the stable
+   * (maximum) rate.
+   *
+   * <p>The returned {@code RateLimiter} starts in a "cold" state (i.e. the
+   * warmup period will follow), and if it is left unused for long enough, it
+   * will return to that state.
+   *
+   * @param permitsPerSecond the rate of the returned {@code RateLimiter},
+   *     measured in how many permits become available per second
+   * @param warmupPeriod the duration of the period where the {@code
+   *     RateLimiter} ramps up its rate, before reaching its stable (maximum)
+   *     rate
+   * @param unit the time unit of the warmupPeriod argument
+   * @throws IllegalArgumentException if {@code permitsPerSecond} is negative or
+   *     zero or {@code warmupPeriod} is negative
+   */
+  @SuppressWarnings("GoodTime") // should accept a java.time.Duration
+  public static RateLimiter create(double permitsPerSecond, long warmupPeriod,
+                                   TimeUnit unit) {
+    checkArgument(warmupPeriod >= 0, "warmupPeriod must not be negative: %s",
+                  warmupPeriod);
+    return create(permitsPerSecond, warmupPeriod, unit, 3.0,
+                  SleepingStopwatch.createFromSystemTimer());
+  }
+
+  @VisibleForTesting
+  static RateLimiter create(double permitsPerSecond, long warmupPeriod,
+                            TimeUnit unit, double coldFactor,
+                            SleepingStopwatch stopwatch) {
+    RateLimiter rateLimiter =
+        new SmoothWarmingUp(stopwatch, warmupPeriod, unit, coldFactor);
+    rateLimiter.setRate(permitsPerSecond);
+    return rateLimiter;
+  }
+
+  /**
+   * The underlying timer; used both to measure elapsed time and sleep as
+   * necessary. A separate object to facilitate testing.
+   */
+  private final SleepingStopwatch stopwatch;
+
+  // Can't be initialized in the constructor because mocks don't call the
+  // constructor.
+  private volatile @Nullable Object mutexDoNotUseDirectly;
+
+  private Object mutex() {
+    Object mutex = mutexDoNotUseDirectly;
+    if (mutex == null) {
+      synchronized (this) {
+        mutex = mutexDoNotUseDirectly;
+        if (mutex == null) {
+          mutexDoNotUseDirectly = mutex = new Object();
+        }
+      }
+    }
+    return mutex;
+  }
+
+  RateLimiter(SleepingStopwatch stopwatch) {
+    this.stopwatch = checkNotNull(stopwatch);
+  }
+
+  /**
+   * Updates the stable rate of this {@code RateLimiter}, that is, the {@code
+   * permitsPerSecond} argument provided in the factory method that constructed
+   * the {@code RateLimiter}. Currently throttled threads will <b>not</b> be
+   * awakened as a result of this invocation, thus they do not observe the new
+   * rate; only subsequent requests will.
+   *
+   * <p>Note though that, since each request repays (by waiting, if necessary)
+   * the cost of the <i>previous</i> request, this means that the very next
+   * request after an invocation to {@code setRate} will not be affected by the
+   * new rate; it will pay the cost of the previous request, which is in terms
+   * of the previous rate.
+   *
+   * <p>The behavior of the {@code RateLimiter} is not modified in any other
+   * way, e.g. if the {@code RateLimiter} was configured with a warmup period of
+   * 20 seconds, it still has a warmup period of 20 seconds after this method
+   * invocation.
+   *
+   * @param permitsPerSecond the new stable rate of this {@code RateLimiter}
+   * @throws IllegalArgumentException if {@code permitsPerSecond} is negative or
+   *     zero
+   */
+  public final void setRate(double permitsPerSecond) {
+    checkArgument(permitsPerSecond > 0.0 && !Double.isNaN(permitsPerSecond),
+                  "rate must be positive");
+    synchronized (mutex()) {
+      doSetRate(permitsPerSecond, stopwatch.readNanos());
+    }
+  }
+
+  abstract void doSetRate(double permitsPerSecond, long nowNanos);
+
+  /**
+   * Returns the stable rate (as {@code permits per seconds}) with which this
+   * {@code RateLimiter} is configured with. The initial value of this is the
+   * same as the {@code permitsPerSecond} argument passed in the factory method
+   * that produced this {@code RateLimiter}, and it is only updated after
+   * invocations to {@linkplain #setRate}.
+   */
+  public final double getRate() {
+    synchronized (mutex()) { return doGetRate(); }
+  }
+
+  abstract double doGetRate();
+
+  /**
+   * Acquires a single permit from this {@code RateLimiter}, blocking until the
+   * request can be granted. Tells the amount of time slept, if any.
+   *
+   * <p>This method is equivalent to {@code acquire(1)}.
+   *
+   * @return time spent sleeping to enforce rate, in seconds; 0.0 if not
+   *     rate-limited
+   * @since 16.0 (present in 13.0 with {@code void} return type})
+   */
+  @CanIgnoreReturnValue
+  public double acquire() {
+    return acquire(1);
+  }
+
+  /**
+   * Acquires the given number of permits from this {@code RateLimiter},
+   * blocking until the request can be granted. Tells the amount of time slept,
+   * if any.
+   *
+   * @param permits the number of permits to acquire
+   * @return time spent sleeping to enforce rate, in seconds; 0.0 if not
+   *     rate-limited
+   * @throws IllegalArgumentException if the requested number of permits is
+   *     negative or zero
+   * @since 16.0 (present in 13.0 with {@code void} return type})
+   */
+  @CanIgnoreReturnValue
+  public double acquire(int permits) {
+    long nanosToWait = reserve(permits);
+    stopwatch.sleepNanosUninterruptibly(nanosToWait);
+    return 1.0 * nanosToWait / SECONDS.toNanos(1L);
+  }
+
+  /**
+   * Reserves the given number of permits from this {@code RateLimiter} for
+   * future use, returning the number of NANOSECONDS until the reservation can
+   * be consumed.
+   *
+   * @return time in NANOSECONDS to wait until the resource can be acquired,
+   *     never negative
+   */
+  final long reserve(int permits) {
+    checkPermits(permits);
+    synchronized (mutex()) {
+      return reserveAndGetWaitLength(permits, stopwatch.readNanos());
+    }
+  }
+
+  /**
+   * Acquires a permit from this {@code RateLimiter} if it can be obtained
+   * without exceeding the specified {@code timeout}, or returns {@code false}
+   * immediately (without waiting) if the permit would not have been granted
+   * before the timeout expired.
+   *
+   * <p>This method is equivalent to {@code tryAcquire(1, timeout, unit)}.
+   *
+   * @param timeout the maximum time to wait for the permit. Negative values are
+   *     treated as zero.
+   * @param unit the time unit of the timeout argument
+   * @return {@code true} if the permit was acquired, {@code false} otherwise
+   * @throws IllegalArgumentException if the requested number of permits is
+   *     negative or zero
+   */
+  @SuppressWarnings("GoodTime") // should accept a java.time.Duration
+  public boolean tryAcquire(long timeout, TimeUnit unit) {
+    return tryAcquire(1, timeout, unit);
+  }
+
+  /**
+   * Acquires permits from this {@link RateLimiter} if it can be acquired
+   * immediately without delay.
+   *
+   * <p>This method is equivalent to {@code tryAcquire(permits, 0, anyUnit)}.
+   *
+   * @param permits the number of permits to acquire
+   * @return {@code true} if the permits were acquired, {@code false} otherwise
+   * @throws IllegalArgumentException if the requested number of permits is
+   *     negative or zero
+   * @since 14.0
+   */
+  public boolean tryAcquire(int permits) {
+    return tryAcquire(permits, 0, NANOSECONDS);
+  }
+
+  /**
+   * Acquires a permit from this {@link RateLimiter} if it can be acquired
+   * immediately without delay.
+   *
+   * <p>This method is equivalent to {@code tryAcquire(1)}.
+   *
+   * @return {@code true} if the permit was acquired, {@code false} otherwise
+   * @since 14.0
+   */
+  public boolean tryAcquire() { return tryAcquire(1, 0, NANOSECONDS); }
+
+  /**
+   * Acquires the given number of permits from this {@code RateLimiter} if it
+   * can be obtained without exceeding the specified {@code timeout}, or returns
+   * {@code false} immediately (without waiting) if the permits would not have
+   * been granted before the timeout expired.
+   *
+   * @param permits the number of permits to acquire
+   * @param timeout the maximum time to wait for the permits. Negative values
+   *     are treated as zero.
+   * @param unit the time unit of the timeout argument
+   * @return {@code true} if the permits were acquired, {@code false} otherwise
+   * @throws IllegalArgumentException if the requested number of permits is
+   *     negative or zero
+   */
+  @SuppressWarnings("GoodTime") // should accept a java.time.Duration
+  public boolean tryAcquire(int permits, long timeout, TimeUnit unit) {
+    long timeoutNanos = max(unit.toNanos(timeout), 0);
+    checkPermits(permits);
+    long nanosToWait;
+    synchronized (mutex()) {
+      long nowNanos = stopwatch.readNanos();
+      if (!canAcquire(nowNanos, timeoutNanos)) {
+        return false;
+      } else {
+        nanosToWait = reserveAndGetWaitLength(permits, nowNanos);
+      }
+    }
+    stopwatch.sleepNanosUninterruptibly(nanosToWait);
+    return true;
+  }
+
+  private boolean canAcquire(long nowNanos, long timeoutNanos) {
+    return queryEarliestAvailable(nowNanos) - timeoutNanos <= nowNanos;
+  }
+
+  /**
+   * Reserves next ticket and returns the wait time that the caller must wait
+   * for.
+   *
+   * @return the required wait time, never negative
+   */
+  final long reserveAndGetWaitLength(int permits, long nowNanos) {
+    long momentAvailable = reserveEarliestAvailable(permits, nowNanos);
+    return max(momentAvailable - nowNanos, 0);
+  }
+
+  /**
+   * Returns the earliest time that permits are available (with one caveat).
+   *
+   * @return the time that permits are available, or, if permits are available
+   *     immediately, an arbitrary past or present time
+   */
+  abstract long queryEarliestAvailable(long nowNanos);
+
+  /**
+   * Reserves the requested number of permits and returns the time that those
+   * permits can be used (with one caveat).
+   *
+   * @return the time that the permits may be used, or, if the permits may be
+   *     used immediately, an arbitrary past or present time
+   */
+  abstract long reserveEarliestAvailable(int permits, long nowNanos);
+
+  @Override
+  public String toString() {
+    return String.format(Locale.ROOT, "RateLimiter[stableRate=%3.1fqps]",
+                         getRate());
+  }
+
+  abstract static class SleepingStopwatch {
+    /** Constructor for use by subclasses. */
+    protected SleepingStopwatch() {}
+
+    /*
+     * We always hold the mutex when calling this. TODO(cpovirk): Is that
+     * important? Perhaps we need to guarantee that each call to
+     * reserveEarliestAvailable, etc. sees a value >= the previous? Also, is it
+     * OK that we don't hold the mutex when sleeping?
+     */
+    protected abstract long readNanos();
+
+    protected abstract void sleepNanosUninterruptibly(long nanos);
+
+    public static SleepingStopwatch createFromSystemTimer() {
+      return new SleepingStopwatch() {
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+
+        @Override
+        protected long readNanos() {
+          return stopwatch.elapsed(NANOSECONDS);
+        }
+
+        @Override
+        protected void sleepNanosUninterruptibly(long nanos) {
+          if (nanos > 0) {
+            sleepUninterruptibly(nanos, NANOSECONDS);
+          }
+        }
+      };
+    }
+  }
+
+  private static void checkPermits(int permits) {
+    checkArgument(permits > 0, "Requested permits (%s) must be positive",
+                  permits);
+  }
+}

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/SmoothRateLimiter.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/SmoothRateLimiter.java
@@ -1,0 +1,397 @@
+/*
+ * Copyright (C) 2012 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.openmessaging.benchmark.utils;
+
+import static java.lang.Math.min;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import com.google.common.annotations.GwtIncompatible;
+import com.google.common.math.LongMath;
+import java.util.concurrent.TimeUnit;
+
+@GwtIncompatible
+abstract class SmoothRateLimiter extends RateLimiter {
+  /*
+   * How is the RateLimiter designed, and why?
+   *
+   * The primary feature of a RateLimiter is its "stable rate", the maximum rate that is should
+   * allow at normal conditions. This is enforced by "throttling" incoming requests as needed, i.e.
+   * compute, for an incoming request, the appropriate throttle time, and make the calling thread
+   * wait as much.
+   *
+   * The simplest way to maintain a rate of QPS is to keep the timestamp of the last granted
+   * request, and ensure that (1/QPS) seconds have elapsed since then. For example, for a rate of
+   * QPS=5 (5 tokens per second), if we ensure that a request isn't granted earlier than 200ms after
+   * the last one, then we achieve the intended rate. If a request comes and the last request was
+   * granted only 100ms ago, then we wait for another 100ms. At this rate, serving 15 fresh permits
+   * (i.e. for an acquire(15) request) naturally takes 3 seconds.
+   *
+   * It is important to realize that such a RateLimiter has a very superficial memory of the past:
+   * it only remembers the last request. What if the RateLimiter was unused for a long period of
+   * time, then a request arrived and was immediately granted? This RateLimiter would immediately
+   * forget about that past underutilization. This may result in either underutilization or
+   * overflow, depending on the real world consequences of not using the expected rate.
+   *
+   * Past underutilization could mean that excess resources are available. Then, the RateLimiter
+   * should speed up for a while, to take advantage of these resources. This is important when the
+   * rate is applied to networking (limiting bandwidth), where past underutilization typically
+   * translates to "almost empty buffers", which can be filled immediately.
+   *
+   * On the other hand, past underutilization could mean that "the server responsible for handling
+   * the request has become less ready for future requests", i.e. its caches become stale, and
+   * requests become more likely to trigger expensive operations (a more extreme case of this
+   * example is when a server has just booted, and it is mostly busy with getting itself up to
+   * speed).
+   *
+   * To deal with such scenarios, we add an extra dimension, that of "past underutilization",
+   * modeled by "storedPermits" variable. This variable is zero when there is no underutilization,
+   * and it can grow up to maxStoredPermits, for sufficiently large underutilization. So, the
+   * requested permits, by an invocation acquire(permits), are served from:
+   *
+   * - stored permits (if available)
+   *
+   * - fresh permits (for any remaining permits)
+   *
+   * How this works is best explained with an example:
+   *
+   * For a RateLimiter that produces 1 token per second, every second that goes by with the
+   * RateLimiter being unused, we increase storedPermits by 1. Say we leave the RateLimiter unused
+   * for 10 seconds (i.e., we expected a request at time X, but we are at time X + 10 seconds before
+   * a request actually arrives; this is also related to the point made in the last paragraph), thus
+   * storedPermits becomes 10.0 (assuming maxStoredPermits >= 10.0). At that point, a request of
+   * acquire(3) arrives. We serve this request out of storedPermits, and reduce that to 7.0 (how
+   * this is translated to throttling time is discussed later). Immediately after, assume that an
+   * acquire(10) request arriving. We serve the request partly from storedPermits, using all the
+   * remaining 7.0 permits, and the remaining 3.0, we serve them by fresh permits produced by the
+   * rate limiter.
+   *
+   * We already know how much time it takes to serve 3 fresh permits: if the rate is
+   * "1 token per second", then this will take 3 seconds. But what does it mean to serve 7 stored
+   * permits? As explained above, there is no unique answer. If we are primarily interested to deal
+   * with underutilization, then we want stored permits to be given out /faster/ than fresh ones,
+   * because underutilization = free resources for the taking. If we are primarily interested to
+   * deal with overflow, then stored permits could be given out /slower/ than fresh ones. Thus, we
+   * require a (different in each case) function that translates storedPermits to throtting time.
+   *
+   * This role is played by storedPermitsToWaitTime(double storedPermits, double permitsToTake). The
+   * underlying model is a continuous function mapping storedPermits (from 0.0 to maxStoredPermits)
+   * onto the 1/rate (i.e. intervals) that is effective at the given storedPermits. "storedPermits"
+   * essentially measure unused time; we spend unused time buying/storing permits. Rate is
+   * "permits / time", thus "1 / rate = time / permits". Thus, "1/rate" (time / permits) times
+   * "permits" gives time, i.e., integrals on this function (which is what storedPermitsToWaitTime()
+   * computes) correspond to minimum intervals between subsequent requests, for the specified number
+   * of requested permits.
+   *
+   * Here is an example of storedPermitsToWaitTime: If storedPermits == 10.0, and we want 3 permits,
+   * we take them from storedPermits, reducing them to 7.0, and compute the throttling for these as
+   * a call to storedPermitsToWaitTime(storedPermits = 10.0, permitsToTake = 3.0), which will
+   * evaluate the integral of the function from 7.0 to 10.0.
+   *
+   * Using integrals guarantees that the effect of a single acquire(3) is equivalent to {
+   * acquire(1); acquire(1); acquire(1); }, or { acquire(2); acquire(1); }, etc, since the integral
+   * of the function in [7.0, 10.0] is equivalent to the sum of the integrals of [7.0, 8.0], [8.0,
+   * 9.0], [9.0, 10.0] (and so on), no matter what the function is. This guarantees that we handle
+   * correctly requests of varying weight (permits), /no matter/ what the actual function is - so we
+   * can tweak the latter freely. (The only requirement, obviously, is that we can compute its
+   * integrals).
+   *
+   * Note well that if, for this function, we chose a horizontal line, at height of exactly (1/QPS),
+   * then the effect of the function is non-existent: we serve storedPermits at exactly the same
+   * cost as fresh ones (1/QPS is the cost for each). We use this trick later.
+   *
+   * If we pick a function that goes /below/ that horizontal line, it means that we reduce the area
+   * of the function, thus time. Thus, the RateLimiter becomes /faster/ after a period of
+   * underutilization. If, on the other hand, we pick a function that goes /above/ that horizontal
+   * line, then it means that the area (time) is increased, thus storedPermits are more costly than
+   * fresh permits, thus the RateLimiter becomes /slower/ after a period of underutilization.
+   *
+   * Last, but not least: consider a RateLimiter with rate of 1 permit per second, currently
+   * completely unused, and an expensive acquire(100) request comes. It would be nonsensical to just
+   * wait for 100 seconds, and /then/ start the actual task. Why wait without doing anything? A much
+   * better approach is to /allow/ the request right away (as if it was an acquire(1) request
+   * instead), and postpone /subsequent/ requests as needed. In this version, we allow starting the
+   * task immediately, and postpone by 100 seconds future requests, thus we allow for work to get
+   * done in the meantime instead of waiting idly.
+   *
+   * This has important consequences: it means that the RateLimiter doesn't remember the time of the
+   * _last_ request, but it remembers the (expected) time of the _next_ request. This also enables
+   * us to tell immediately (see tryAcquire(timeout)) whether a particular timeout is enough to get
+   * us to the point of the next scheduling time, since we always maintain that. And what we mean by
+   * "an unused RateLimiter" is also defined by that notion: when we observe that the
+   * "expected arrival time of the next request" is actually in the past, then the difference (now -
+   * past) is the amount of time that the RateLimiter was formally unused, and it is that amount of
+   * time which we translate to storedPermits. (We increase storedPermits with the amount of permits
+   * that would have been produced in that idle time). So, if rate == 1 permit per second, and
+   * arrivals come exactly one second after the previous, then storedPermits is _never_ increased --
+   * we would only increase it for arrivals _later_ than the expected one second.
+   */
+
+  /**
+   * This implements the following function where coldInterval = coldFactor * stableInterval.
+   *
+   * <pre>
+   *          ^ throttling
+   *          |
+   *    cold  +                  /
+   * interval |                 /.
+   *          |                / .
+   *          |               /  .   ← "warmup period" is the area of the trapezoid between
+   *          |              /   .     thresholdPermits and maxPermits
+   *          |             /    .
+   *          |            /     .
+   *          |           /      .
+   *   stable +----------/  WARM .
+   * interval |          .   UP  .
+   *          |          . PERIOD.
+   *          |          .       .
+   *        0 +----------+-------+--------------→ storedPermits
+   *          0 thresholdPermits maxPermits
+   * </pre>
+   *
+   * Before going into the details of this particular function, let's keep in mind the basics:
+   *
+   * <ol>
+   *   <li>The state of the RateLimiter (storedPermits) is a vertical line in this figure.
+   *   <li>When the RateLimiter is not used, this goes right (up to maxPermits)
+   *   <li>When the RateLimiter is used, this goes left (down to zero), since if we have
+   *       storedPermits, we serve from those first
+   *   <li>When _unused_, we go right at a constant rate! The rate at which we move to the right is
+   *       chosen as maxPermits / warmupPeriod. This ensures that the time it takes to go from 0 to
+   *       maxPermits is equal to warmupPeriod.
+   *   <li>When _used_, the time it takes, as explained in the introductory class note, is equal to
+   *       the integral of our function, between X permits and X-K permits, assuming we want to
+   *       spend K saved permits.
+   * </ol>
+   *
+   * <p>In summary, the time it takes to move to the left (spend K permits), is equal to the area of
+   * the function of width == K.
+   *
+   * <p>Assuming we have saturated demand, the time to go from maxPermits to thresholdPermits is
+   * equal to warmupPeriod. And the time to go from thresholdPermits to 0 is warmupPeriod/2. (The
+   * reason that this is warmupPeriod/2 is to maintain the behavior of the original implementation
+   * where coldFactor was hard coded as 3.)
+   *
+   * <p>It remains to calculate thresholdsPermits and maxPermits.
+   *
+   * <ul>
+   *   <li>The time to go from thresholdPermits to 0 is equal to the integral of the function
+   *       between 0 and thresholdPermits. This is thresholdPermits * stableIntervals. By (5) it is
+   *       also equal to warmupPeriod/2. Therefore
+   *       <blockquote>
+   *       thresholdPermits = 0.5 * warmupPeriod / stableInterval
+   *       </blockquote>
+   *
+   *   <li>The time to go from maxPermits to thresholdPermits is equal to the integral of the
+   *       function between thresholdPermits and maxPermits. This is the area of the pictured
+   *       trapezoid, and it is equal to 0.5 * (stableInterval + coldInterval) * (maxPermits -
+   *       thresholdPermits). It is also equal to warmupPeriod, so
+   *       <blockquote>
+   *       maxPermits = thresholdPermits + 2 * warmupPeriod / (stableInterval + coldInterval)
+   *       </blockquote>
+   *
+   * </ul>
+   */
+  static final class SmoothWarmingUp extends SmoothRateLimiter {
+    private final long warmupPeriodNanos;
+    /**
+     * The slope of the line from the stable interval (when permits == 0), to the cold interval
+     * (when permits == maxPermits)
+     */
+    private double slope;
+    private double thresholdPermits;
+    private double coldFactor;
+
+    SmoothWarmingUp(
+        SleepingStopwatch stopwatch, long warmupPeriod, TimeUnit timeUnit, double coldFactor) {
+      super(stopwatch);
+      this.warmupPeriodNanos = timeUnit.toNanos(warmupPeriod);
+      this.coldFactor = coldFactor;
+    }
+
+    @Override
+    void doSetRate(double permitsPerSecond, double stableIntervalNanos) {
+      double oldMaxPermits = maxPermits;
+      double coldIntervalNanos = stableIntervalNanos * coldFactor;
+      thresholdPermits = 0.5 * warmupPeriodNanos / stableIntervalNanos;
+      maxPermits =
+          thresholdPermits + 2.0 * warmupPeriodNanos / (stableIntervalNanos + coldIntervalNanos);
+      slope = (coldIntervalNanos - stableIntervalNanos) / (maxPermits - thresholdPermits);
+      if (oldMaxPermits == Double.POSITIVE_INFINITY) {
+        // if we don't special-case this, we would get storedPermits == NaN, below
+        storedPermits = 0.0;
+      } else {
+        storedPermits =
+            (oldMaxPermits == 0.0)
+                ? maxPermits // initial state is cold
+                : storedPermits * maxPermits / oldMaxPermits;
+      }
+    }
+
+    @Override
+    long storedPermitsToWaitTime(double storedPermits, double permitsToTake) {
+      double availablePermitsAboveThreshold = storedPermits - thresholdPermits;
+      long nanos = 0;
+      // measuring the integral on the right part of the function (the climbing line)
+      if (availablePermitsAboveThreshold > 0.0) {
+        double permitsAboveThresholdToTake = min(availablePermitsAboveThreshold, permitsToTake);
+        // TODO(cpovirk): Figure out a good name for this variable.
+        double length = permitsToTime(availablePermitsAboveThreshold)
+                + permitsToTime(availablePermitsAboveThreshold - permitsAboveThresholdToTake);
+        nanos = (long) (permitsAboveThresholdToTake * length / 2.0);
+        permitsToTake -= permitsAboveThresholdToTake;
+      }
+      // measuring the integral on the left part of the function (the horizontal line)
+      nanos += (long) (stableIntervalNanos * permitsToTake);
+      return nanos;
+    }
+
+    private double permitsToTime(double permits) {
+      return stableIntervalNanos + permits * slope;
+    }
+
+    @Override
+    double coolDownIntervalNanos() {
+      return warmupPeriodNanos / maxPermits;
+    }
+  }
+
+  /**
+   * This implements a "bursty" RateLimiter, where storedPermits are translated to zero throttling.
+   * The maximum number of permits that can be saved (when the RateLimiter is unused) is defined in
+   * terms of time, in this sense: if a RateLimiter is 2qps, and this time is specified as 10
+   * seconds, we can save up to 2 * 10 = 20 permits.
+   */
+  static final class SmoothBursty extends SmoothRateLimiter {
+    /** The work (permits) of how many seconds can be saved up if this RateLimiter is unused? */
+    final double maxBurstSeconds;
+
+    SmoothBursty(SleepingStopwatch stopwatch, double maxBurstSeconds) {
+      super(stopwatch);
+      this.maxBurstSeconds = maxBurstSeconds;
+    }
+
+    @Override
+    void doSetRate(double permitsPerSecond, double stableIntervalNanos) {
+      double oldMaxPermits = this.maxPermits;
+      maxPermits = maxBurstSeconds * permitsPerSecond;
+      if (oldMaxPermits == Double.POSITIVE_INFINITY) {
+        // if we don't special-case this, we would get storedPermits == NaN, below
+        storedPermits = maxPermits;
+      } else {
+        storedPermits =
+            (oldMaxPermits == 0.0)
+                ? 0.0 // initial state
+                : storedPermits * maxPermits / oldMaxPermits;
+      }
+    }
+
+    @Override
+    long storedPermitsToWaitTime(double storedPermits, double permitsToTake) {
+      return 0L;
+    }
+
+    @Override
+    double coolDownIntervalNanos() {
+      return stableIntervalNanos;
+    }
+  }
+
+  /**
+   * The currently stored permits.
+   */
+  double storedPermits;
+
+  /**
+   * The maximum number of stored permits.
+   */
+  double maxPermits;
+
+  /**
+   * The interval between two unit requests, at our stable rate. E.g., a stable rate of 5 permits
+   * per second has a stable interval of 200ms.
+   */
+  double stableIntervalNanos;
+
+  /**
+   * The time when the next request (no matter its size) will be granted. After granting a request,
+   * this is pushed further in the future. Large requests push this further than small requests.
+   */
+  private long nextFreeTicketNanos = 0L; // could be either in the past or future
+
+  private SmoothRateLimiter(SleepingStopwatch stopwatch) {
+    super(stopwatch);
+  }
+
+  @Override
+  final void doSetRate(double permitsPerSecond, long nowNanos) {
+    resync(nowNanos);
+    double stableIntervalNanos = SECONDS.toNanos(1L) / permitsPerSecond;
+    this.stableIntervalNanos = stableIntervalNanos;
+    doSetRate(permitsPerSecond, stableIntervalNanos);
+  }
+
+  abstract void doSetRate(double permitsPerSecond, double stableIntervalNanos);
+
+  @Override
+  final double doGetRate() {
+    return SECONDS.toNanos(1L) / stableIntervalNanos;
+  }
+
+  @Override
+  final long queryEarliestAvailable(long nowNanos) {
+    return nextFreeTicketNanos;
+  }
+
+  @Override
+  final long reserveEarliestAvailable(int requiredPermits, long nowNanos) {
+    resync(nowNanos);
+    long returnValue = nextFreeTicketNanos;
+    double storedPermitsToSpend = min(requiredPermits, this.storedPermits);
+    double freshPermits = requiredPermits - storedPermitsToSpend;
+    long waitNanos =
+        storedPermitsToWaitTime(this.storedPermits, storedPermitsToSpend)
+            + (long) (freshPermits * stableIntervalNanos);
+
+    this.nextFreeTicketNanos = LongMath.saturatedAdd(nextFreeTicketNanos, waitNanos);
+    this.storedPermits -= storedPermitsToSpend;
+    return returnValue;
+  }
+
+  /**
+   * Translates a specified portion of our currently stored permits which we want to spend/acquire,
+   * into a throttling time. Conceptually, this evaluates the integral of the underlying function we
+   * use, for the range of [(storedPermits - permitsToTake), storedPermits].
+   *
+   * <p>This always holds: {@code 0 <= permitsToTake <= storedPermits}
+   */
+  abstract long storedPermitsToWaitTime(double storedPermits, double permitsToTake);
+
+  /**
+   * Returns the number of nanoseconds during cool down that we have to wait to get a new permit.
+   */
+  abstract double coolDownIntervalNanos();
+
+  /**
+   * Updates {@code storedPermits} and {@code nextFreeTicketNanos} based on the current time.
+   */
+  void resync(long nowNanos) {
+    // if nextFreeTicket is in the past, resync to now
+    if (nowNanos > nextFreeTicketNanos) {
+      double newPermits = (nowNanos - nextFreeTicketNanos) / coolDownIntervalNanos();
+      storedPermits = min(maxPermits, storedPermits + newPermits);
+      nextFreeTicketNanos = nowNanos;
+    }
+  }
+}

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
@@ -40,7 +40,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.base.Preconditions;
-import com.google.common.util.concurrent.RateLimiter;
+import io.openmessaging.benchmark.utils.RateLimiter;
 
 import org.HdrHistogram.Recorder;
 import org.apache.bookkeeper.stats.Counter;


### PR DESCRIPTION
Ported over Google's guava rate limiter and modified it to use nano
seconds resolution timer. This allow us to run workloads with more than
one million messages per second.

Signed-off-by: Michal Maslanka <michal@vectorized.io>