### PR TITLE
Failure in init code on second run

### DIFF
--- a/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkDriver.java
+++ b/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkDriver.java
@@ -36,6 +36,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -49,6 +50,8 @@ import io.openmessaging.benchmark.driver.BenchmarkConsumer;
 import io.openmessaging.benchmark.driver.BenchmarkDriver;
 import io.openmessaging.benchmark.driver.BenchmarkProducer;
 import io.openmessaging.benchmark.driver.ConsumerCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class KafkaBenchmarkDriver implements BenchmarkDriver {
 
@@ -95,9 +98,13 @@ public class KafkaBenchmarkDriver implements BenchmarkDriver {
                 // Delete all existing topics
                 DeleteTopicsResult deletes = admin.deleteTopics(topics);
                 deletes.all().get();
-            } catch (InterruptedException | ExecutionException e) {
-                e.printStackTrace();
-                throw new IOException(e);
+            } catch (InterruptedException |  ExecutionException e) {
+                if (e.getCause() instanceof UnknownTopicOrPartitionException) {
+                    log.warn("Topic(s) appeared to be deleted already (race condition)");
+                } else {
+                    log.error("Could not delete topic(s) due to {}", e);
+                    throw new IOException(e);
+                }
             }
         }
     }
@@ -106,6 +113,8 @@ public class KafkaBenchmarkDriver implements BenchmarkDriver {
     public String getTopicNamePrefix() {
         return "test-topic";
     }
+
+    private static final Logger log = LoggerFactory.getLogger(KafkaBenchmarkDriver.class);
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override

--- a/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/RedpandaBenchmarkDriver.java
+++ b/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/RedpandaBenchmarkDriver.java
@@ -34,6 +34,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -95,9 +96,13 @@ public class RedpandaBenchmarkDriver implements BenchmarkDriver {
                 // Delete all existing topics
                 DeleteTopicsResult deletes = admin.deleteTopics(topics);
                 deletes.all().get();
-            } catch (InterruptedException | ExecutionException e) {
-                e.printStackTrace();
-                throw new IOException(e);
+            } catch (InterruptedException |  ExecutionException e) {
+                if (e.getCause() instanceof UnknownTopicOrPartitionException) {
+                    log.warn("Topic(s) appeared to be deleted already (race condition)");
+                } else {
+                    log.error("Could not delete topic(s) due to {}", e);
+                    throw new IOException(e);
+                }
             }
         }
     }


### PR DESCRIPTION
There is an issue where one the second run of a job, n-1 of the workers throw an exception and come back with a 500 status code.

Root cause is that in the driver init code, they try to delete all topics, however there is a race condition where they all try and delete them at the same time. Only one succeeds and the other n-1 fail.