### PR TITLE
Annotate additional metadata in the result file

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
@@ -66,6 +66,9 @@ public class Benchmark {
 
         @Parameter(names = { "-o", "--output" }, description = "Output", required = false)
         public String output;
+
+	@Parameter(names = { "-v", "--service-version" }, description = "Optional version of the service being benchmarked, embedded in the final result", required = false)
+	public String serviceVersion;
     }
 
     public static void main(String[] args) throws Exception {
@@ -137,6 +140,7 @@ public class Benchmark {
 
             arguments.drivers.forEach(driverConfig -> {
                 try {
+		    String beginTime = dateFormat.format(new Date());
                     File driverConfigFile = new File(driverConfig);
                     DriverConfiguration driverConfiguration = mapper.readValue(driverConfigFile,
                             DriverConfiguration.class);
@@ -151,6 +155,9 @@ public class Benchmark {
                     WorkloadGenerator generator = new WorkloadGenerator(driverConfiguration.name, workload, worker);
 
                     TestResult result = generator.run();
+		    result.beginTime = beginTime;
+		    result.endTime = dateFormat.format(new Date());
+		    result.version = arguments.serviceVersion;
 
                     String fileName;
                     if (arguments.output != null  && arguments.output.length() > 0) {

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/TestResult.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/TestResult.java
@@ -26,6 +26,9 @@ import java.util.TreeMap;
 public class TestResult {
     public String workload;
     public String driver;
+    public String version;
+    public String beginTime;
+    public String endTime;
     public long messageSize;
     public int topics;
     public int partitions;


### PR DESCRIPTION
Includes the following fields.

* An optional version of the service passed along by the user with --service-version. This is a plain string and can be anything like an actual version/commit etc. This is embedded in the result.json
* beginTime (beginning time of the workload)
* endTime (end time of the workload)

The goal is to include as much metadata as we can in the result.json so that we need not look elsewhere to figure out when it was run or what it was run against. 