### PR TITLE
Coalesce async offset commits

### DIFF
--- a/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkConsumer.java
+++ b/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkConsumer.java
@@ -79,7 +79,7 @@ public class KafkaBenchmarkConsumer implements BenchmarkConsumer, OffsetCommitCa
                     /* We're only going to submit an async commit request if:
                         - autoCommit is disabled AND
                         - there are offsets to commit AND
-                            - offsetCommitLingerMs is zero (the default, so no waiting for async callbacks at all) OR
+                            - offsetCommitLingerMs is negative OR
                             - we've waited lingerMs milliseconds since the last callback completed (+ve or -ve)
                      */
                     long now = System.currentTimeMillis();

--- a/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkConsumer.java
+++ b/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkConsumer.java
@@ -44,7 +44,7 @@ public class KafkaBenchmarkConsumer implements BenchmarkConsumer, OffsetCommitCa
     private long offsetCommitLingerMs;
     private boolean autoCommit;
 
-    private final String OFFSET_COMMIT_CONFIG = "offsetCommitLingerMs";
+    private static final String OFFSET_COMMIT_CONFIG = "offsetCommitLingerMs";
 
     public KafkaBenchmarkConsumer(KafkaConsumer<String, byte[]> consumer,
                                   Properties consumerConfig,
@@ -85,7 +85,7 @@ public class KafkaBenchmarkConsumer implements BenchmarkConsumer, OffsetCommitCa
                     long now = System.currentTimeMillis();
                     long timeSinceOffsetCommitComplete = now - timeSinceOffsetCommitCallback;
                     if (!autoCommit && !offsetMap.isEmpty() &&
-                            (offsetCommitLingerMs == 0  || timeSinceOffsetCommitComplete >= offsetCommitLingerMs)) {
+                            (offsetCommitLingerMs < 0  || timeSinceOffsetCommitComplete >= offsetCommitLingerMs)) {
                         log.debug("msec since last offset commit complete: {}", timeSinceOffsetCommitComplete);
                         // Async commit all messages polled so far
                         consumer.commitAsync(offsetMap, this);

--- a/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkConsumer.java
+++ b/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkConsumer.java
@@ -62,7 +62,7 @@ public class KafkaBenchmarkConsumer implements BenchmarkConsumer, OffsetCommitCa
         this.callback = callback;
 
         this.offsetCommitLingerMs = Long.valueOf((String)consumerConfig.getOrDefault(OFFSET_COMMIT_CONFIG, "0"));
-        this.autoCommit = Boolean.valueOf((String)consumerConfig.getOrDefault(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,"false"));
+        this.autoCommit = Boolean.valueOf((String)consumerConfig.getOrDefault(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,"true"));
 
         this.consumerTask = this.executor.submit(() -> {
             long lastOffsetNanos = System.nanoTime();


### PR DESCRIPTION
Changes to move the offset commit behaviour back closer to the default behaviour, but also to avoid flooding the Kafka client with async commits. At the very least this will only submit async requests once the previous async request has come back.

New behaviour:
We're only going to submit an async commit request if:

- autoCommit is disabled AND
- there are offsets to commit AND
  - offsetCommitLingerMs is zero (the default, so no waiting for async callbacks at all) OR
  - we've waited lingerMs milliseconds since the last callback completed (+ve or -ve)
                     