### PR TITLE
Update README.md

### DIFF
--- a/driver-redpanda/README.md
+++ b/driver-redpanda/README.md
@@ -5,6 +5,9 @@
 - Terraform
 
 - Ansible
+	- cloudalchemy.node_exporter
+	- cloudalchemy.prometheus
+	- cloudalchemy.grafana
 
 - Python 3 set as default.
 


### PR DESCRIPTION
When running the ansible-playbook there are 3 roles that are undocumented prereqs. This fixes that by adding the bullet list below the ansible requirements so a user knows to load these via ansible-galaxy.