### PR TITLE
Avoid OMB hot nodes by using Strictly Uniform Sticky Partitioner

### DIFF
--- a/driver-kafka/pom.xml
+++ b/driver-kafka/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
-			<version>3.2.0</version>
+			<version>3.3.1</version>
 		</dependency>
 	</dependencies>
 

--- a/driver-redpanda/pom.xml
+++ b/driver-redpanda/pom.xml
@@ -54,7 +54,7 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
-			<version>3.2.0</version>
+			<version>3.3.1</version>
 		</dependency>
 
 		<!-- Custom build -->


### PR DESCRIPTION
This PR updates the Kafka and Redpanda drivers to use the newest kafka-client version where the Strictly Uniform Sticky Partitioner is the default partitioner. 