### PR TITLE
Update Ubuntu AMI

### DIFF
--- a/driver-redpanda/deploy/terraform.tfvars
+++ b/driver-redpanda/deploy/terraform.tfvars
@@ -1,7 +1,7 @@
 public_key_path = "~/.ssh/redpanda_aws.pub"
 region          = "us-west-2"
 az		        = "us-west-2a"
-ami             = "ami-0928f4202481dfdf6"
+ami             = "ami-0d31d7c9fc9503726"
 profile         = "default"
 
 instance_types = {


### PR DESCRIPTION
The old AMI has problems with TLS certs that cause problems downloading certificates from the Grafana repo