### PR TITLE
fix omb build failure

### DIFF
--- a/driver-nats-streaming/pom.xml
+++ b/driver-nats-streaming/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>io.nats</groupId>
             <artifactId>java-nats-streaming</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.0</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/driver-nats-streaming/pom.xml
+++ b/driver-nats-streaming/pom.xml
@@ -24,6 +24,11 @@
 
     <artifactId>driver-nats-streaming</artifactId>
     <dependencies>
+       <dependency>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+          <version>29.0-jre</version>
+        </dependency>
         <dependency>
             <groupId>io.nats</groupId>
             <artifactId>java-nats-streaming</artifactId>


### PR DESCRIPTION
### Hotfix
CI failed to build omb with the following error:
```
[ERROR] Failed to execute goal on project driver-nats-streaming: Could not resolve dependencies for project io.openmessaging.benchmark:driver-nats-streaming:jar:0.0.1-SNAPSHOT: Failed to collect dependencies at io.nats:java-nats-streaming:jar:2.1.0 -> com.google.protobuf:protobuf-java:jar:3.22.0-RC1: Failed to read artifact descriptor for com.google.protobuf:protobuf-java:jar:3.22.0-RC1: Could not find artifact com.google.protobuf:protobuf-parent:pom:3.22.0-RC1 in central (https://repo.maven.apache.org/maven2) -> [Help 1]
```

This PR:
* updates the version of java-nats-streaming: `2.1.0` -> `2.2.0`: according to  https://github.com/nats-io/stan.java/releases/tag/2.2.0 updates the protobuf version
* adds explicit dependency for `guava`: The above version update breaks the `driver-nats-streaming/src/main/java/io/openmessaging/benchmark/driver/natsStreaming/NatsStreamingBenchmarkDriver.java` script. More specifically, it cannot find the com.google.common.io  package:
```
[ERROR] /opt/openmessaging-benchmark/driver-nats-streaming/src/main/java/io/openmessaging/benchmark/driver/natsStreaming/NatsStreamingBenchmarkDriver.java:[19,28] package com.google.common.io does not exist
```

ref https://github.com/redpanda-data/devprod/issues/566