### PR TITLE
Fix to enable the benchmark script to be called from any location

### DIFF
--- a/bin/benchmark
+++ b/bin/benchmark
@@ -13,10 +13,19 @@
 # limitations under the License.
 #
 
-if [ -d "./lib" ]; then
-        CLASSPATH=$CLASSPATH:lib/*
+# https://stackoverflow.com/questions/59895/how-do-i-get-the-directory-where-a-bash-script-is-located-from-within-the-script
+SOURCE=${BASH_SOURCE[0]}
+while [ -L "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+  SOURCE=$(readlink "$SOURCE")
+  [[ $SOURCE != /* ]] && SOURCE=$DIR/$SOURCE # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR=$( cd -P "$( dirname "$SOURCE" )/.." >/dev/null 2>&1 && pwd )
+
+if [ -d "${DIR}/lib" ]; then
+        CLASSPATH=$CLASSPATH:${DIR}lib/*
 else
-    CLASSPATH=benchmark-framework/target/classes:`cat benchmark-framework/target/classpath.txt`
+    CLASSPATH=${DIR}/benchmark-framework/target/classes:`cat ${DIR}/benchmark-framework/target/classpath.txt`
 fi
 
 if [ -z "$HEAP_OPTS" ]

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -23,7 +23,7 @@ done
 DIR=$( cd -P "$( dirname "$SOURCE" )/.." >/dev/null 2>&1 && pwd )
 
 if [ -d "${DIR}/lib" ]; then
-        CLASSPATH=$CLASSPATH:${DIR}lib/*
+        CLASSPATH=$CLASSPATH:${DIR}/lib/*
 else
     CLASSPATH=${DIR}/benchmark-framework/target/classes:`cat ${DIR}/benchmark-framework/target/classpath.txt`
 fi


### PR DESCRIPTION
Fix to enable the benchmark script to be called from any location rather than just the install directory (also allows non-root running)