### PR TITLE
Remove log.flush.interval.messages from Kafka server.properties

### DIFF
--- a/driver-kafka/deploy/ssd-deployment/templates/server.properties
+++ b/driver-kafka/deploy/ssd-deployment/templates/server.properties
@@ -53,5 +53,3 @@ replica.fetch.max.bytes=10485760
 num.network.threads=16
 
 num.io.threads=16
-
-log.flush.interval.messages=1


### PR DESCRIPTION
Apache Kafka flush behavior can be set from the driver config so it is best to leave log.flush.interval.messages out of server properties. Many users who benchmark Kafka from this copy of OMB may leave out the 'flush.messages' driver config and not realise that Kafka will be flushing on each message batch in any case.