### PR TITLE
Allow using an existing topic name

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
@@ -89,6 +89,15 @@ public class Benchmark {
         public String serviceVersion;
     }
 
+    /**
+     * Load and validate workload.
+     */
+    private static Workload readWorkload(File file) throws IOException {
+        Workload w = mapper.readValue(file, Workload.class);
+        w.validate();
+        return w;
+    }
+
     public static void main(String[] args) throws Exception {
         final Arguments arguments = new Arguments();
         JCommander jc = new JCommander(arguments);
@@ -145,7 +154,7 @@ public class Benchmark {
             File file = new File(path);
             String name = file.getName().substring(0, file.getName().lastIndexOf('.'));
 
-            workloads.put(name, mapper.readValue(file, Workload.class));
+            workloads.put(name, readWorkload(file));
         }
 
         log.info("Workloads: {}", writer.writeValueAsString(workloads));

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
@@ -13,13 +13,25 @@
  */
 package io.openmessaging.benchmark;
 
+import java.util.Collections;
+import java.util.List;
+
 import io.openmessaging.benchmark.utils.distributor.KeyDistributorType;
 
 public class Workload {
     public String name;
 
-    /** Number of topics to create in the test */
+    /**
+     * Number of topics to create in the test, must be zero iff
+     * existingTopicList is used.
+     */
     public int topics;
+
+    /**
+     * A list of existing topics names to use instead of randomly generated
+     * new topics. If this is list is non-empty, topics must be zero.
+     */
+    public List<String> existingTopicList = Collections.emptyList();
 
     /** Number of partitions each topic will contain */
     public int partitionsPerTopic;
@@ -69,6 +81,16 @@ public class Workload {
         checkNonNegative(consumerPerSubscription, "consumerPerSubscription");
         checkNonNegative(producerRate, "producerRate");
         checkNonNegative(consumerBacklogSizeGB, "consumerBacklogSizeGB");
+
+        if (topics > 0 && !existingTopicList.isEmpty()) {
+            throw new RuntimeException(String.format(
+                "Workload specified both non-zero topic count (%d) and explicit topic list: these options " +
+                "are mutually incompatible.", topics));
+        }
+
+        if (topics == 0 && existingTopicList.isEmpty()) {
+            throw new RuntimeException("The workload must specify non-zero topics or a non-empty existingTopicList");
+        }
     }
 
     private void checkNonNegative(long val, String fieldName) {

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
@@ -54,4 +54,27 @@ public class Workload {
     public int warmupDurationMinutes = 30;
     public int sampleRateMillis = 10000;
     public int testDurationMinutes;
+
+    /**
+     * Perform basic validation on the workload and throw an exception if
+     * any invalid configuration is found.
+     */
+    public void validate() {
+        checkNonNegative(topics, "topics");
+        checkNonNegative(partitionsPerTopic, "partitionsPerTopic");
+        checkNonNegative(messageSize, "messageSize");
+        checkNonNegative(randomizedPayloadPoolSize, "randomizedPayloadPoolSize");
+        checkNonNegative(subscriptionsPerTopic, "subscriptionsPerTopic");
+        checkNonNegative(producersPerTopic, "producersPerTopic");
+        checkNonNegative(consumerPerSubscription, "consumerPerSubscription");
+        checkNonNegative(producerRate, "producerRate");
+        checkNonNegative(consumerBacklogSizeGB, "consumerBacklogSizeGB");
+    }
+
+    private void checkNonNegative(long val, String fieldName) {
+        if (val < 0) {
+            throw new RuntimeException(String.format(
+                "In workload file field %s had invalid negative value: %d", fieldName, val));
+        }
+    }
 }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -68,8 +68,9 @@ public class WorkloadGenerator implements AutoCloseable {
 
     public TestResult run() throws Exception {
         Timer timer = new Timer();
-        List<String> topics = worker.createTopics(new TopicsInfo(workload.topics, workload.partitionsPerTopic));
-        log.info("Created {} topics in {} ms", topics.size(), timer.elapsedMillis());
+        TopicsInfo ti = TopicsInfo.fromWorkload(workload);
+        List<String> topics = worker.createOrValidateTopics(ti);
+        log.info("{} {} topics in {} ms", ti.isExistingTopics() ? "Validated" : "Created", topics.size(), timer.elapsedMillis());
 
         createConsumers(topics);
         createProducers(topics);
@@ -165,7 +166,7 @@ public class WorkloadGenerator implements AutoCloseable {
         long end = start + 60 * 1000;
         while (System.currentTimeMillis() < end) {
             CountersStats stats = worker.getCountersStats();
-	    
+
             if (stats.messagesReceived < expectedMessages) {
                 try {
                     Thread.sleep(100);
@@ -182,7 +183,7 @@ public class WorkloadGenerator implements AutoCloseable {
         }
         else {
             log.info("All consumers are ready");
-        }        
+        }
     }
 
     /**

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
@@ -76,7 +76,7 @@ public class DistributedWorkersEnsemble implements Worker {
 	// If there is an odd number of workers then allocate the extra to consumption.
 	int numberOfProducerWorkers = extraConsumerWorkers ? (workers.size() + 2) / 3 : workers.size() / 2;
 	List<List<String>> partitions = Lists.partition(Lists.reverse(workers), workers.size() - numberOfProducerWorkers);
-	this.producerWorkers = partitions.get(1); 
+	this.producerWorkers = partitions.get(1);
 	this.consumerWorkers = partitions.get(0);
 
         log.info("Workers list - producers: {}", producerWorkers);
@@ -93,7 +93,7 @@ public class DistributedWorkersEnsemble implements Worker {
 
     @Override
     @SuppressWarnings("unchecked")
-    public List<String> createTopics(TopicsInfo topicsInfo) throws IOException {
+    public List<String> createOrValidateTopics(TopicsInfo topicsInfo) throws IOException {
         // Create all topics from a single worker node
         try {
             return (List<String>) post(workers.get(0), "/create-topics", writer.writeValueAsBytes(topicsInfo), List.class)
@@ -224,7 +224,7 @@ public class DistributedWorkersEnsemble implements Worker {
             try {
                 stats.publishLatency.add(Histogram.decodeFromCompressedByteBuffer(
                         ByteBuffer.wrap(is.publishLatencyBytes), TimeUnit.SECONDS.toMicros(30)));
-                
+
                 stats.scheduleLatency.add(Histogram.decodeFromCompressedByteBuffer(
                     ByteBuffer.wrap(is.scheduleLatencyBytes), TimeUnit.SECONDS.toMicros(30)));
 

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/Worker.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/Worker.java
@@ -28,7 +28,21 @@ public interface Worker extends AutoCloseable {
 
     void initializeDriver(File configurationFile) throws IOException;
 
-    List<String> createTopics(TopicsInfo topicsInfo) throws IOException;
+    /**
+     * Given a TopicsInfo object, create any necessary topics.
+     *
+     * The TopicsInfo object may request the creation of N topics or it
+     * may specify that a list of existing topics are to be used, in
+     * which case this method may optionally validate that they exist.
+     *
+     * In any case, the list of topic names to be used in the test is
+     * returned.
+     *
+     * @param topicsInfo the spceification of the topics to be used
+     * @return the list of topic names to be used
+     * @throws IOException
+     */
+    List<String> createOrValidateTopics(TopicsInfo topicsInfo) throws IOException;
 
     void createProducers(List<String> topics) throws IOException;
 

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/WorkerHandler.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/WorkerHandler.java
@@ -77,7 +77,7 @@ public class WorkerHandler {
     private void handleCreateTopics(Context ctx) throws Exception {
         TopicsInfo topicsInfo = mapper.readValue(ctx.body(), TopicsInfo.class);
         log.info("Received create topics request for topics: {}", ctx.body());
-        List<String> topics = localWorker.createTopics(topicsInfo);
+        List<String> topics = localWorker.createOrValidateTopics(topicsInfo);
         ctx.result(writer.writeValueAsString(topics));
     }
 

--- a/driver-api/src/main/java/io/openmessaging/benchmark/driver/BenchmarkDriver.java
+++ b/driver-api/src/main/java/io/openmessaging/benchmark/driver/BenchmarkDriver.java
@@ -27,7 +27,7 @@ public interface BenchmarkDriver extends AutoCloseable {
      * file.
      * <p>
      * The format of the configuration file is specific to the driver implementation.
-     * 
+     *
      * @param configurationFile
      * @param statsLogger stats logger to collect stats from benchmark driver
      * @throws IOException
@@ -45,16 +45,27 @@ public interface BenchmarkDriver extends AutoCloseable {
     CompletableFuture<Void> createTopic(String topic, int partitions);
 
     /**
+     * Optionally validate that a given topic exists, returning false if it does not.
+     *
+     * By default the implementatin simply returns true without checking, which is
+     * sufficient if the producer or consumer themselves return timely and informative
+     * errors when the topic doesn't exist.
+     */
+    default CompletableFuture<Boolean> validateTopicExists(String topicName) {
+        return CompletableFuture.completedFuture(true);
+    }
+
+    /**
      * Create a producer for a given topic
      */
     CompletableFuture<BenchmarkProducer> createProducer(String topic);
 
     /**
      * Create a benchmark consumer relative to one particular topic and subscription.
-     * 
+     *
      * It is responsibility of the driver implementation to invoke the <code>consumerCallback</code> each time a message
      * is received.
-     * 
+     *
      * @param topic
      * @param subscriptionName
      * @param consumerCallback


### PR DESCRIPTION
Currently the OMB benchmark framework always creates new test topics.
In some cases it is useful to use an existing topic, which has specific
configuration or state which can't be set up by OMB. To satisfy this
case, we add the topic to specify a list of existing topics in the
workload file. If this property is specified the list of topics is
used for the test.