### PR TITLE
Wasm Data Transform support for OMB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .project
 .settings
 .pydevproject
+.vim
 target
 /.metadata/
 *.pyc

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
@@ -32,6 +32,10 @@ public class Workload {
      * new topics. If this is list is non-empty, topics must be zero.
      */
     public List<String> existingTopicList = Collections.emptyList();
+    /** producer only `existingTopicList`. */
+    public List<String> existingProduceTopicList = Collections.emptyList();
+    /** consumer only `existingTopicList`. */
+    public List<String> existingConsumeTopicList = Collections.emptyList();
 
     /** Number of partitions each topic will contain */
     public int partitionsPerTopic;
@@ -82,14 +86,20 @@ public class Workload {
         checkNonNegative(producerRate, "producerRate");
         checkNonNegative(consumerBacklogSizeGB, "consumerBacklogSizeGB");
 
-        if (topics > 0 && !existingTopicList.isEmpty()) {
+        boolean usingExistingTopics = !existingTopicList.isEmpty() || !existingConsumeTopicList.isEmpty() || !existingProduceTopicList.isEmpty();
+
+        if (topics > 0 && usingExistingTopics) {
             throw new RuntimeException(String.format(
                 "Workload specified both non-zero topic count (%d) and explicit topic list: these options " +
                 "are mutually incompatible.", topics));
         }
 
-        if (topics == 0 && existingTopicList.isEmpty()) {
+        if (topics == 0 && !usingExistingTopics) {
             throw new RuntimeException("The workload must specify non-zero topics or a non-empty existingTopicList");
+        }
+
+        if (existingTopicList.isEmpty() && (existingConsumeTopicList.isEmpty() != existingProduceTopicList.isEmpty())) {
+            throw new RuntimeException("The workload must specify a non-empty existingTopicList");
         }
     }
 

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
@@ -155,7 +155,7 @@ public class LocalWorker implements Worker, ConsumerCallback {
         boolean useExisting = topicsInfo.isExistingTopics();
 
         if (useExisting) {
-            for (String topicName : topicsInfo.existingTopics) {
+            for (String topicName : topicsInfo.allExistingTopics()) {
                 if (!benchmarkDriver.validateTopicExists(topicName).join()) {
                     throw new RuntimeException(String.format("Topic specified in workload does not exist: %s",
                         topicName));


### PR DESCRIPTION
This patch set allows for having different topics that are produced and consumed too.

The main motivation for this is to run OMB against a Wasm powered Data Transform and see the E2E latency.

This comes with an example transform that converts json into avro:

OMB should produce into a topic called `json` using the payload in `payload/payload-1Kb.json`. The deployed data transform will take that json and convert it to avro and write to the `avro` topic, which OMB will consume from.

Commits:
- Add .vim to gitignore
- Add the ability to specify existing topics for produce or consume
- Add an example json -> avro data transform
- Add an example json payload for the wasm transform
