### PR TITLE
Migrate from `String` to `byte[]` keys and add new "INCREMENTING_KEY" type

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/IncrementingKey.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/IncrementingKey.java
@@ -1,0 +1,12 @@
+package io.openmessaging.benchmark.utils.distributor;
+
+public class IncrementingKey extends KeyDistributor {
+
+  int value = 0;
+  final int len = getLength();
+
+  @Override
+  public String next() {
+    return String.valueOf((value++) % len);
+  }
+}

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/IncrementingKey.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/IncrementingKey.java
@@ -1,12 +1,22 @@
 package io.openmessaging.benchmark.utils.distributor;
 
+import java.nio.ByteBuffer;
+
 public class IncrementingKey extends KeyDistributor {
 
   int value = 0;
-  final int len = getLength();
+  final int len = getLength(); // This never changes in the parent class?
+
+  final ByteBuffer buffer = ByteBuffer.allocate(8);
 
   @Override
   public String next() {
     return String.valueOf((value++) % len);
+  }
+
+  @Override
+  public byte[] nextBytes() {
+    buffer.putInt(0, (value++) % len);
+    return buffer.array();
   }
 }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/IncrementingKey.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/IncrementingKey.java
@@ -4,10 +4,9 @@ import java.nio.ByteBuffer;
 
 public class IncrementingKey extends KeyDistributor {
 
-  int value = 0;
-  final int len = getLength(); // This never changes in the parent class?
+  private int value = 0;
 
-  final ByteBuffer buffer = ByteBuffer.allocate(Integer.SIZE / Byte.SIZE);
+  private final ByteBuffer buffer = ByteBuffer.allocate(Integer.SIZE / Byte.SIZE);
 
   @Override
   public String next() {

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/IncrementingKey.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/IncrementingKey.java
@@ -7,16 +7,16 @@ public class IncrementingKey extends KeyDistributor {
   int value = 0;
   final int len = getLength(); // This never changes in the parent class?
 
-  final ByteBuffer buffer = ByteBuffer.allocate(8);
+  final ByteBuffer buffer = ByteBuffer.allocate(Integer.SIZE / Byte.SIZE);
 
   @Override
   public String next() {
-    return String.valueOf((value++) % len);
+    return String.valueOf(value++);
   }
 
   @Override
   public byte[] nextBytes() {
-    buffer.putInt(0, (value++) % len);
-    return buffer.array();
+    buffer.putInt(0, value++);
+    return buffer.array().clone();
   }
 }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/KeyDistributor.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/KeyDistributor.java
@@ -56,6 +56,9 @@ public abstract class KeyDistributor {
             case RANDOM_NANO:
                 keyDistributor = new RandomNano();
                 break;
+            case INCREMENTING_KEY:
+                keyDistributor = new IncrementingKey();
+                break;
         }
         return keyDistributor;
     }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/KeyDistributor.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/KeyDistributor.java
@@ -15,6 +15,7 @@ package io.openmessaging.benchmark.utils.distributor;
 
 import com.google.common.io.BaseEncoding;
 
+import java.nio.ByteBuffer;
 import java.util.Random;
 
 public abstract class KeyDistributor {
@@ -22,7 +23,7 @@ public abstract class KeyDistributor {
     private static final int UNIQUE_COUNT = 10_000;
     private static final int KEY_BYTE_SIZE = 7;
 
-    private static final String[] randomKeys = new String[UNIQUE_COUNT];
+    private static final ByteBuffer[] randomKeys = new ByteBuffer[UNIQUE_COUNT];
     private static final Random random = new Random();
 
     static {
@@ -30,12 +31,17 @@ public abstract class KeyDistributor {
         byte[] buffer = new byte[KEY_BYTE_SIZE];
         for (int i = 0; i < randomKeys.length; i++) {
             random.nextBytes(buffer);
-            randomKeys[i] = BaseEncoding.base64Url().omitPadding().encode(buffer);
+            randomKeys[i] = ByteBuffer.allocate(buffer.length);
+            randomKeys[i].put(buffer);
         }
     }
 
     protected String get(int index) {
-        return randomKeys[index];
+        return BaseEncoding.base64Url().omitPadding().encode(randomKeys[index].array());
+    }
+
+    protected byte[] getBytes(int index) {
+        return randomKeys[index].array();
     }
 
     protected int getLength() {
@@ -43,6 +49,8 @@ public abstract class KeyDistributor {
     }
 
     public abstract String next();
+
+    public abstract byte[] nextBytes();
 
     public static KeyDistributor build(KeyDistributorType keyType) {
         KeyDistributor keyDistributor = null;

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/KeyDistributorType.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/KeyDistributorType.java
@@ -31,4 +31,6 @@ public enum KeyDistributorType {
      * Random distribution based on System.nanoTime()
      */
     RANDOM_NANO,
+
+    INCREMENTING_KEY,
 }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/KeyDistributorType.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/KeyDistributorType.java
@@ -23,7 +23,7 @@ public enum KeyDistributorType {
     NO_KEY,
 
     /**
-     * Genarate a finite number of "keys" and cycle through them in round-robin fashion
+     * Generate a finite number of "keys" and cycle through them in round-robin fashion
      */
     KEY_ROUND_ROBIN,
 
@@ -32,5 +32,9 @@ public enum KeyDistributorType {
      */
     RANDOM_NANO,
 
+    /**
+     * Generates incrementing key values (eventually wrapping after 2^32-1 iterations),
+     * relying on producer to decide on distribution scheme.
+     */
     INCREMENTING_KEY,
 }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/KeyRoundRobin.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/KeyRoundRobin.java
@@ -19,10 +19,11 @@ import javax.annotation.concurrent.NotThreadSafe;
 public class KeyRoundRobin extends KeyDistributor {
 
     private int currentIndex = 0;
+    private final int len = getLength();
 
     @Override
     public String next() {
-        if (++currentIndex >= getLength()) {
+        if (++currentIndex >= len) {
             currentIndex = 0;
         }
         return get(currentIndex);
@@ -30,7 +31,7 @@ public class KeyRoundRobin extends KeyDistributor {
 
     @Override
     public byte[] nextBytes() {
-        if (++currentIndex >= getLength()) {
+        if (++currentIndex >= len) {
             currentIndex = 0;
         }
         return getBytes(currentIndex);

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/KeyRoundRobin.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/KeyRoundRobin.java
@@ -27,4 +27,12 @@ public class KeyRoundRobin extends KeyDistributor {
         }
         return get(currentIndex);
     }
+
+    @Override
+    public byte[] nextBytes() {
+        if (++currentIndex >= getLength()) {
+            currentIndex = 0;
+        }
+        return getBytes(currentIndex);
+    }
 }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/NoKeyDistributor.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/NoKeyDistributor.java
@@ -17,7 +17,6 @@ import java.nio.ByteBuffer;
 
 public class NoKeyDistributor extends KeyDistributor {
 
-    final static ByteBuffer buffer = ByteBuffer.wrap(new byte[] { 0 });
     @Override
     public String next() {
         return null;
@@ -25,6 +24,6 @@ public class NoKeyDistributor extends KeyDistributor {
 
     @Override
     public byte[] nextBytes() {
-        return buffer.array();
+        return null;
     }
 }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/NoKeyDistributor.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/NoKeyDistributor.java
@@ -13,7 +13,6 @@
  */
 package io.openmessaging.benchmark.utils.distributor;
 
-import java.nio.ByteBuffer;
 
 public class NoKeyDistributor extends KeyDistributor {
 

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/NoKeyDistributor.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/NoKeyDistributor.java
@@ -13,7 +13,6 @@
  */
 package io.openmessaging.benchmark.utils.distributor;
 
-
 public class NoKeyDistributor extends KeyDistributor {
 
     @Override

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/NoKeyDistributor.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/NoKeyDistributor.java
@@ -13,10 +13,18 @@
  */
 package io.openmessaging.benchmark.utils.distributor;
 
+import java.nio.ByteBuffer;
+
 public class NoKeyDistributor extends KeyDistributor {
 
+    final static ByteBuffer buffer = ByteBuffer.wrap(new byte[] { 0 });
     @Override
     public String next() {
         return null;
+    }
+
+    @Override
+    public byte[] nextBytes() {
+        return buffer.array();
     }
 }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/RandomNano.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/RandomNano.java
@@ -18,6 +18,8 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public class RandomNano extends KeyDistributor {
 
+    private final int len = getLength();
+
     public String next() {
         int randomIndex = Math.abs((int) System.nanoTime() % getLength());
         return get(randomIndex);
@@ -25,7 +27,8 @@ public class RandomNano extends KeyDistributor {
 
     @Override
     public byte[] nextBytes() {
-        return new byte[0];
+        int randomIndex = (int) System.nanoTime() & Integer.MAX_VALUE;
+        return getBytes(randomIndex % len);
     }
 
 }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/RandomNano.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/RandomNano.java
@@ -22,4 +22,10 @@ public class RandomNano extends KeyDistributor {
         int randomIndex = Math.abs((int) System.nanoTime() % getLength());
         return get(randomIndex);
     }
+
+    @Override
+    public byte[] nextBytes() {
+        return new byte[0];
+    }
+
 }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/RandomNano.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/RandomNano.java
@@ -21,13 +21,13 @@ public class RandomNano extends KeyDistributor {
     private final int len = getLength();
 
     public String next() {
-        int randomIndex = Math.abs((int) System.nanoTime() % getLength());
+        int randomIndex = Math.abs((int) System.nanoTime() % len);
         return get(randomIndex);
     }
 
     @Override
     public byte[] nextBytes() {
-        int randomIndex = (int) System.nanoTime() & Integer.MAX_VALUE;
+        int randomIndex = (int) (System.nanoTime() & Integer.MAX_VALUE);
         return getBytes(randomIndex % len);
     }
 

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
@@ -236,7 +236,7 @@ public class LocalWorker implements Worker, ConsumerCallback {
                         final long intendedSendTime = rateLimiter.acquire();
                         uninterruptibleSleepNs(intendedSendTime);
                         final long sendTime = System.nanoTime();
-                        CompletableFuture<Void> f = producer.sendAsync(Optional.ofNullable(keyDistributor.next()), payloadData);
+                        CompletableFuture<Void> f = producer.sendAsync(keyDistributor.nextBytes(), payloadData);
                         long scheduleMicros = TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - sendTime);
                         scheduleLatencyRecorder.recordValue(scheduleMicros);
                         cumulativeScheduleLatencyRecorder.recordValue(scheduleMicros);

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/utils/distributor/KeyDistributorTest.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/utils/distributor/KeyDistributorTest.java
@@ -1,5 +1,6 @@
 package io.openmessaging.benchmark.utils.distributor;
 
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -17,7 +18,7 @@ public class KeyDistributorTest {
    * Microbenchmark for the {@link KeyDistributor} implementations. Calls `.next()` in a tight loop.
    */
   @Test
-  @Ignore("slow test")
+  @Ignore("Slow test.")
   public void benchmarkKeyDistributors() {
     final Map<KeyDistributorType, Long> results = new HashMap<>();
     System.out.printf("Using test iterations of: %,d\n", ITERATIONS);
@@ -50,7 +51,7 @@ public class KeyDistributorTest {
   }
 
   @Test
-  @Ignore("slow test")
+  @Ignore("Slow test.")
   public void benchmarkByteArrayKeyDistributors() {
     final Map<KeyDistributorType, Long> results = new HashMap<>();
     System.out.printf("Using test iterations of: %,d\n", ITERATIONS);
@@ -83,15 +84,17 @@ public class KeyDistributorTest {
   }
 
   @Test
-  @Ignore("slow test")
+  @Ignore("Slow test.")
   public void testRandNanoKeyCoverage() {
-    RandomNano rn = new RandomNano();
-    Set<Integer> set = new HashSet<>();
+    final RandomNano rn = new RandomNano();
+    final Set<Integer> set = new HashSet<>();
 
     for (long i = 0; i < ITERATIONS; i++) {
       set.add(ByteBuffer.wrap(rn.nextBytes()).getInt());
     }
 
     System.out.println("Set cardinality: " + set.size());
+    Assert.assertTrue("should produce better than 80% coverage",
+        set.size() > 0.8 * rn.getLength());
   }
 }

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/utils/distributor/KeyDistributorTest.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/utils/distributor/KeyDistributorTest.java
@@ -15,7 +15,7 @@ public class KeyDistributorTest {
   @Test
   public void benchmarkKeyDistributors() {
     final Map<KeyDistributorType, Long> results = new HashMap<>();
-    System.out.println("Using test iterations of: " + ITERATIONS);
+    System.out.printf("Using test iterations of: %,d\n", ITERATIONS);
 
     for (KeyDistributorType keyType : KeyDistributorType.values()) {
       KeyDistributor distributor = KeyDistributor.build(keyType);
@@ -34,8 +34,8 @@ public class KeyDistributorTest {
     System.out.printf("%-20s %-20s %-20s\n", "Key Distributor", "Duration (s)", "Rate (calls/s)");
     results.forEach((k, v) -> {
       float seconds = v / 1e9f;
-      float rate = ITERATIONS / seconds;
-      System.out.printf("%-20s %-20f %-20f\n", k, seconds, rate);
+      long rate = (long) (ITERATIONS / seconds);
+      System.out.printf("%-20s %,-20f %,-20d\n", k, seconds, rate);
     });
   }
 }

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/utils/distributor/KeyDistributorTest.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/utils/distributor/KeyDistributorTest.java
@@ -1,0 +1,41 @@
+package io.openmessaging.benchmark.utils.distributor;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class KeyDistributorTest {
+
+  public static final long ITERATIONS = Integer.MAX_VALUE * 2L;
+
+  /**
+   * Microbenchmark for the {@link KeyDistributor} implementations. Calls `.next()` in a tight loop.
+   */
+  @Test
+  public void benchmarkKeyDistributors() {
+    final Map<KeyDistributorType, Long> results = new HashMap<>();
+    System.out.println("Using test iterations of: " + ITERATIONS);
+
+    for (KeyDistributorType keyType : KeyDistributorType.values()) {
+      KeyDistributor distributor = KeyDistributor.build(keyType);
+      // 3 times around the sun...
+      System.out.println("Testing " + keyType);
+      final long start = System.nanoTime();
+      for (long i = 0; i < ITERATIONS; i++) {
+        distributor.next();
+      }
+      final long result = System.nanoTime() - start;
+      results.put(keyType, result);
+    }
+    System.out.println("------------------------------------------------");
+
+    // Show results.
+    System.out.printf("%-20s %-20s %-20s\n", "Key Distributor", "Duration (s)", "Rate (calls/s)");
+    results.forEach((k, v) -> {
+      float seconds = v / 1e9f;
+      float rate = ITERATIONS / seconds;
+      System.out.printf("%-20s %-20f %-20f\n", k, seconds, rate);
+    });
+  }
+}

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/utils/distributor/KeyDistributorTest.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/utils/distributor/KeyDistributorTest.java
@@ -1,25 +1,35 @@
 package io.openmessaging.benchmark.utils.distributor;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
+import java.nio.ByteBuffer;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public class KeyDistributorTest {
 
-  public static final long ITERATIONS = Integer.MAX_VALUE * 2L;
+  public static final long ITERATIONS = Integer.MAX_VALUE;
 
   /**
    * Microbenchmark for the {@link KeyDistributor} implementations. Calls `.next()` in a tight loop.
    */
   @Test
+  @Ignore("slow test")
   public void benchmarkKeyDistributors() {
     final Map<KeyDistributorType, Long> results = new HashMap<>();
     System.out.printf("Using test iterations of: %,d\n", ITERATIONS);
 
     for (KeyDistributorType keyType : KeyDistributorType.values()) {
       KeyDistributor distributor = KeyDistributor.build(keyType);
-      // 3 times around the sun...
+
+      System.out.println("Warming up " + keyType);
+      for (long i = 0; i < ITERATIONS; i++) {
+        distributor.next();
+      }
+
       System.out.println("Testing " + keyType);
       final long start = System.nanoTime();
       for (long i = 0; i < ITERATIONS; i++) {
@@ -40,13 +50,19 @@ public class KeyDistributorTest {
   }
 
   @Test
+  @Ignore("slow test")
   public void benchmarkByteArrayKeyDistributors() {
     final Map<KeyDistributorType, Long> results = new HashMap<>();
     System.out.printf("Using test iterations of: %,d\n", ITERATIONS);
 
     for (KeyDistributorType keyType : KeyDistributorType.values()) {
       KeyDistributor distributor = KeyDistributor.build(keyType);
-      // 3 times around the sun...
+
+      System.out.println("Warming up " + keyType);
+      for (long i = 0; i < ITERATIONS; i++) {
+        distributor.next();
+      }
+
       System.out.println("Testing " + keyType);
       final long start = System.nanoTime();
       for (long i = 0; i < ITERATIONS; i++) {
@@ -64,5 +80,18 @@ public class KeyDistributorTest {
       long rate = (long) (ITERATIONS / seconds);
       System.out.printf("%-20s %,-20f %,-20d\n", k, seconds, rate);
     });
+  }
+
+  @Test
+  @Ignore("slow test")
+  public void testRandNanoKeyCoverage() {
+    RandomNano rn = new RandomNano();
+    Set<Integer> set = new HashSet<>();
+
+    for (long i = 0; i < ITERATIONS; i++) {
+      set.add(ByteBuffer.wrap(rn.nextBytes()).getInt());
+    }
+
+    System.out.println("Set cardinality: " + set.size());
   }
 }

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/utils/distributor/KeyDistributorTest.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/utils/distributor/KeyDistributorTest.java
@@ -38,4 +38,31 @@ public class KeyDistributorTest {
       System.out.printf("%-20s %,-20f %,-20d\n", k, seconds, rate);
     });
   }
+
+  @Test
+  public void benchmarkByteArrayKeyDistributors() {
+    final Map<KeyDistributorType, Long> results = new HashMap<>();
+    System.out.printf("Using test iterations of: %,d\n", ITERATIONS);
+
+    for (KeyDistributorType keyType : KeyDistributorType.values()) {
+      KeyDistributor distributor = KeyDistributor.build(keyType);
+      // 3 times around the sun...
+      System.out.println("Testing " + keyType);
+      final long start = System.nanoTime();
+      for (long i = 0; i < ITERATIONS; i++) {
+        distributor.nextBytes();
+      }
+      final long result = System.nanoTime() - start;
+      results.put(keyType, result);
+    }
+    System.out.println("------------------------------------------------");
+
+    // Show results.
+    System.out.printf("%-20s %-20s %-20s\n", "Key Distributor", "Duration (s)", "Rate (calls/s)");
+    results.forEach((k, v) -> {
+      float seconds = v / 1e9f;
+      long rate = (long) (ITERATIONS / seconds);
+      System.out.printf("%-20s %,-20f %,-20d\n", k, seconds, rate);
+    });
+  }
 }

--- a/driver-api/src/main/java/io/openmessaging/benchmark/driver/BenchmarkProducer.java
+++ b/driver-api/src/main/java/io/openmessaging/benchmark/driver/BenchmarkProducer.java
@@ -13,6 +13,7 @@
  */
 package io.openmessaging.benchmark.driver;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;

--- a/driver-api/src/main/java/io/openmessaging/benchmark/driver/BenchmarkProducer.java
+++ b/driver-api/src/main/java/io/openmessaging/benchmark/driver/BenchmarkProducer.java
@@ -13,7 +13,6 @@
  */
 package io.openmessaging.benchmark.driver;
 
-import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;

--- a/driver-api/src/main/java/io/openmessaging/benchmark/driver/BenchmarkProducer.java
+++ b/driver-api/src/main/java/io/openmessaging/benchmark/driver/BenchmarkProducer.java
@@ -13,6 +13,8 @@
  */
 package io.openmessaging.benchmark.driver;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -29,4 +31,8 @@ public interface BenchmarkProducer extends AutoCloseable {
      */
     CompletableFuture<Void> sendAsync(Optional<String> key, byte[] payload);
 
+    default CompletableFuture<Void> sendAsync(byte[] key, byte[] payload) {
+        final Optional<String> stringKey = Optional.of(StandardCharsets.UTF_8.decode(ByteBuffer.wrap(key)).toString());
+        return sendAsync(stringKey, payload);
+    }
 }

--- a/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/RedpandaBenchmarkConsumer.java
+++ b/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/RedpandaBenchmarkConsumer.java
@@ -35,24 +35,24 @@ import io.openmessaging.benchmark.driver.ConsumerCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class RedpandaBenchmarkConsumer implements BenchmarkConsumer {
+public class RedpandaBenchmarkConsumer<T> implements BenchmarkConsumer {
 
     private static final Logger log = LoggerFactory.getLogger(RedpandaBenchmarkConsumer.class);
 
-    private final KafkaConsumer<String, byte[]> consumer;
+    private final KafkaConsumer<T, byte[]> consumer;
 
     private final ExecutorService executor;
     private final Future<?> consumerTask;
     private volatile boolean closing = false;
     private boolean autoCommit;
 
-    public RedpandaBenchmarkConsumer(KafkaConsumer<String, byte[]> consumer,
+    public RedpandaBenchmarkConsumer(KafkaConsumer<T, byte[]> consumer,
                                   Properties consumerConfig,
                                   ConsumerCallback callback) {
         this(consumer, consumerConfig, callback, 100L);
     }
 
-    public RedpandaBenchmarkConsumer(KafkaConsumer<String, byte[]> consumer,
+    public RedpandaBenchmarkConsumer(KafkaConsumer<T, byte[]> consumer,
                                   Properties consumerConfig,
                                   ConsumerCallback callback,
                                   long pollTimeoutMs) {
@@ -64,9 +64,9 @@ public class RedpandaBenchmarkConsumer implements BenchmarkConsumer {
             Map<TopicPartition, OffsetAndMetadata> offsetMap = new HashMap<>();
             while (!closing) {
                 try {
-                    ConsumerRecords<String, byte[]> records = consumer.poll(Duration.ofMillis(pollTimeoutMs));
+                    ConsumerRecords<T, byte[]> records = consumer.poll(Duration.ofMillis(pollTimeoutMs));
 
-                    for (ConsumerRecord<String, byte[]> record : records) {
+                    for (ConsumerRecord<T, byte[]> record : records) {
                         callback.messageReceived(record.value(), record.timestamp());
 
                         offsetMap.put(new TopicPartition(record.topic(), record.partition()),

--- a/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/RedpandaBenchmarkDriver.java
+++ b/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/RedpandaBenchmarkDriver.java
@@ -76,7 +76,7 @@ public class RedpandaBenchmarkDriver implements BenchmarkDriver {
         producerProperties = new Properties();
         commonProperties.forEach((key, value) -> producerProperties.put(key, value));
         producerProperties.load(new StringReader(config.producerConfig));
-        producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
         producerProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
 
         consumerProperties = new Properties();

--- a/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/RedpandaBenchmarkDriver.java
+++ b/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/RedpandaBenchmarkDriver.java
@@ -164,7 +164,7 @@ public class RedpandaBenchmarkDriver implements BenchmarkDriver {
 
     @Override
     public CompletableFuture<BenchmarkProducer> createProducer(String topic) {
-        KafkaProducer<String, byte[]> kafkaProducer = new KafkaProducer<>(producerProperties);
+        KafkaProducer<byte[], byte[]> kafkaProducer = new KafkaProducer<>(producerProperties);
         BenchmarkProducer benchmarkProducer = new RedpandaBenchmarkProducer(kafkaProducer, topic);
         try {
             // Add to producer list to close later

--- a/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/RedpandaBenchmarkDriver.java
+++ b/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/RedpandaBenchmarkDriver.java
@@ -76,13 +76,13 @@ public class RedpandaBenchmarkDriver implements BenchmarkDriver {
         producerProperties = new Properties();
         commonProperties.forEach((key, value) -> producerProperties.put(key, value));
         producerProperties.load(new StringReader(config.producerConfig));
-        producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         producerProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
 
         consumerProperties = new Properties();
         commonProperties.forEach((key, value) -> consumerProperties.put(key, value));
         consumerProperties.load(new StringReader(config.consumerConfig));
-        consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
 
         topicProperties = new Properties();
@@ -184,7 +184,7 @@ public class RedpandaBenchmarkDriver implements BenchmarkDriver {
         Properties properties = new Properties();
         consumerProperties.forEach((key, value) -> properties.put(key, value));
         properties.put(ConsumerConfig.GROUP_ID_CONFIG, subscriptionName);
-        KafkaConsumer<String, byte[]> kafkaConsumer = new KafkaConsumer<>(properties);
+        KafkaConsumer<byte[], byte[]> kafkaConsumer = new KafkaConsumer<>(properties);
         try {
             // Subscribe
             kafkaConsumer.subscribe(Arrays.asList(topic));

--- a/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/RedpandaBenchmarkProducer.java
+++ b/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/RedpandaBenchmarkProducer.java
@@ -28,19 +28,26 @@ import io.openmessaging.benchmark.driver.BenchmarkProducer;
 
 public class RedpandaBenchmarkProducer implements BenchmarkProducer {
 
-    private final KafkaProducer<String, byte[]> producer;
+    private final KafkaProducer<byte[], byte[]> producer;
+
     private final String topic;
 
-    public RedpandaBenchmarkProducer(KafkaProducer<String, byte[]> producer, String topic) {
+    public RedpandaBenchmarkProducer(KafkaProducer<byte[], byte[]> producer, String topic) {
         this.producer = producer;
         this.topic = topic;
     }
 
+
     @Override
     public CompletableFuture<Void> sendAsync(Optional<String> key, byte[] payload) {
-        ProducerRecord<String, byte[]> record = new ProducerRecord<>(topic, key.orElse(null), payload);
+        final byte[] binaryKey = key.map(String::getBytes).orElse(null);
+        return sendAsync(binaryKey, payload);
+    }
 
-        CompletableFuture<Void> future = new CompletableFuture<>();
+    @Override
+    public CompletableFuture<Void> sendAsync(byte[] key, byte[] payload) {
+        final ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(topic, key, payload);
+        final CompletableFuture<Void> future = new CompletableFuture<>();
 
         try {
             producer.send(record, (metadata, exception) -> {

--- a/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/swarm/RedpandaBenchmarkConsumer.java
+++ b/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/swarm/RedpandaBenchmarkConsumer.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.nio.ByteBuffer;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;

--- a/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/swarm/RedpandaBenchmarkDriver.java
+++ b/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/swarm/RedpandaBenchmarkDriver.java
@@ -158,7 +158,7 @@ public class RedpandaBenchmarkDriver implements BenchmarkDriver {
 
     @Override
     public CompletableFuture<BenchmarkProducer> createProducer(String topic) {
-        KafkaProducer<String, byte[]> kafkaProducer = new KafkaProducer<>(producerProperties);
+        KafkaProducer<byte[], byte[]> kafkaProducer = new KafkaProducer<>(producerProperties);
         BenchmarkProducer benchmarkProducer = new RedpandaBenchmarkProducer(nodeId, kafkaProducer, topic);
         try {
             // Add to producer list to close later


### PR DESCRIPTION
Per some internal conversations, this is an experiment in tuning the `KeyDistributor` components to generate `byte[]` instead of Java `String` objects. It's a little lighter weight and some synthetic microbenchmarks make it look like we may be able to generate keys faster.

I'm also experimenting with an incrementing key that will approximate "random" key values by just incrementing an integer value and letting it eventually wrap.

Some results of these tweaks while running on my laptop:

**`String` generation (results sorted manually)**
```
Using test iterations of: 2,147,483,647
Warming up NO_KEY
Testing NO_KEY
Warming up KEY_ROUND_ROBIN
Testing KEY_ROUND_ROBIN
Warming up RANDOM_NANO
Testing RANDOM_NANO
Warming up INCREMENTING_KEY
Testing INCREMENTING_KEY
------------------------------------------------
Key Distributor      Duration (s)         Rate (calls/s)      
NO_KEY                3.617325            593,666,304         
INCREMENTING_KEY     23.564751             91,131,184          
KEY_ROUND_ROBIN      65.748657             32,662,016
RANDOM_NANO          98.478111             21,806,710          
```

**`byte[]` generation (results sorted manually)**
```
Using test iterations of: 2,147,483,647
Warming up NO_KEY
Testing NO_KEY
Warming up KEY_ROUND_ROBIN
Testing KEY_ROUND_ROBIN
Warming up RANDOM_NANO
Testing RANDOM_NANO
Warming up INCREMENTING_KEY
Testing INCREMENTING_KEY
------------------------------------------------
Key Distributor      Duration (s)         Rate (calls/s)      
NO_KEY                0.804360           2,669,804,544
KEY_ROUND_ROBIN       4.463216             481,151,584       
INCREMENTING_KEY     25.426916              84,457,104          
RANDOM_NANO          33.035847              65,004,648          
```

I'm really impressed by how returning `null` when the function signature returns `byte[]` is so much more efficient than when it's `String`.

> Note: The key generation, in general, is very flawed regardless of performance. There's no knobs for the distribution of the randomness (e.g. uniform, gaussian, etc.). _sigh._

I'll need help testing this...I've only done unit testing on my laptop. While my changes to the greater projects compile...this code relies on generics and could have runtime exceptions.