### PR TITLE
Td temp

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/WorkerHandler.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/WorkerHandler.java
@@ -18,6 +18,7 @@ import java.net.HttpURLConnection;
 import java.nio.ByteBuffer;
 import java.util.List;
 
+import org.HdrHistogram.Histogram;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.base.Preconditions;
 import com.google.common.io.Files;
 
 import io.javalin.Context;
@@ -126,34 +128,43 @@ public class WorkerHandler {
         localWorker.stopAll();
     }
 
+    /**
+     * Serialize the given histogram to a byte array.
+     */
+    private byte[] serializeHistogram(Histogram inputHisto) {
+        return serializeHistogram(inputHisto, histogramSerializationBuffer);
+    }
+
+    static byte[] serializeHistogram(Histogram histo, ByteBuffer buffer) {
+        buffer.clear();
+        while (true) {
+            final int outBytes = histo.encodeIntoCompressedByteBuffer(buffer);
+            Preconditions.checkState(outBytes == buffer.position());
+            final int capacity = buffer.capacity();
+            if (outBytes < capacity) {
+                // encoding succesful
+                break;
+            }
+            // We filled the entire buffer, an indication that the buffer was not
+            // large enough, so we double the buffer and try again.
+            // See: https://github.com/HdrHistogram/HdrHistogram/issues/201
+            buffer = ByteBuffer.allocate(capacity * 2);
+        }
+        byte encodedBuffer[] = new byte[buffer.position()];
+        buffer.flip();
+        buffer.get(encodedBuffer);
+        return encodedBuffer;
+    }
+
     private void handlePeriodStats(Context ctx) throws Exception {
         PeriodStats stats = localWorker.getPeriodStats();
 
         // Serialize histograms
-        synchronized (histogramSerializationBuffer) {
-            histogramSerializationBuffer.clear();
-            stats.publishLatency.encodeIntoCompressedByteBuffer(histogramSerializationBuffer);
-            stats.publishLatencyBytes = new byte[histogramSerializationBuffer.position()];
-            histogramSerializationBuffer.flip();
-            histogramSerializationBuffer.get(stats.publishLatencyBytes);
-
-            histogramSerializationBuffer.clear();
-            stats.scheduleLatency.encodeIntoCompressedByteBuffer(histogramSerializationBuffer);
-            stats.scheduleLatencyBytes = new byte[histogramSerializationBuffer.position()];
-            histogramSerializationBuffer.flip();
-            histogramSerializationBuffer.get(stats.scheduleLatencyBytes);
-
-            histogramSerializationBuffer.clear();
-            stats.publishDelayLatency.encodeIntoCompressedByteBuffer(histogramSerializationBuffer);
-            stats.publishDelayLatencyBytes = new byte[histogramSerializationBuffer.position()];
-            histogramSerializationBuffer.flip();
-            histogramSerializationBuffer.get(stats.publishDelayLatencyBytes);
-
-            histogramSerializationBuffer.clear();
-            stats.endToEndLatency.encodeIntoCompressedByteBuffer(histogramSerializationBuffer);
-            stats.endToEndLatencyBytes = new byte[histogramSerializationBuffer.position()];
-            histogramSerializationBuffer.flip();
-            histogramSerializationBuffer.get(stats.endToEndLatencyBytes);
+        synchronized (serializeLock) {
+            stats.publishLatencyBytes      = serializeHistogram(stats.publishLatency);
+            stats.scheduleLatencyBytes     = serializeHistogram(stats.scheduleLatency);
+            stats.publishDelayLatencyBytes = serializeHistogram(stats.publishDelayLatency);
+            stats.endToEndLatencyBytes     = serializeHistogram(stats.endToEndLatency);
         }
 
         ctx.result(writer.writeValueAsString(stats));
@@ -163,30 +174,11 @@ public class WorkerHandler {
         CumulativeLatencies stats = localWorker.getCumulativeLatencies();
 
         // Serialize histograms
-        synchronized (histogramSerializationBuffer) {
-            histogramSerializationBuffer.clear();
-            stats.publishLatency.encodeIntoCompressedByteBuffer(histogramSerializationBuffer);
-            stats.publishLatencyBytes = new byte[histogramSerializationBuffer.position()];
-            histogramSerializationBuffer.flip();
-            histogramSerializationBuffer.get(stats.publishLatencyBytes);
-
-            histogramSerializationBuffer.clear();
-            stats.scheduleLatency.encodeIntoCompressedByteBuffer(histogramSerializationBuffer);
-            stats.scheduleLatencyBytes = new byte[histogramSerializationBuffer.position()];
-            histogramSerializationBuffer.flip();
-            histogramSerializationBuffer.get(stats.scheduleLatencyBytes);
-
-            histogramSerializationBuffer.clear();
-            stats.publishDelayLatency.encodeIntoCompressedByteBuffer(histogramSerializationBuffer);
-            stats.publishDelayLatencyBytes = new byte[histogramSerializationBuffer.position()];
-            histogramSerializationBuffer.flip();
-            histogramSerializationBuffer.get(stats.publishDelayLatencyBytes);
-
-            histogramSerializationBuffer.clear();
-            stats.endToEndLatency.encodeIntoCompressedByteBuffer(histogramSerializationBuffer);
-            stats.endToEndLatencyBytes = new byte[histogramSerializationBuffer.position()];
-            histogramSerializationBuffer.flip();
-            histogramSerializationBuffer.get(stats.endToEndLatencyBytes);
+        synchronized (serializeLock) {
+            stats.publishLatencyBytes      = serializeHistogram(stats.publishLatency);
+            stats.scheduleLatencyBytes     = serializeHistogram(stats.scheduleLatency);
+            stats.publishDelayLatencyBytes = serializeHistogram(stats.publishDelayLatency);
+            stats.endToEndLatencyBytes     = serializeHistogram(stats.endToEndLatency);
         }
 
         ctx.result(writer.writeValueAsString(stats));
@@ -201,7 +193,9 @@ public class WorkerHandler {
         localWorker.resetStats();
     }
 
-    private final ByteBuffer histogramSerializationBuffer = ByteBuffer.allocate(1024 * 1024);
+    private final Object serializeLock = new Object();
+    private ByteBuffer histogramSerializationBuffer = ByteBuffer.allocate(1024 * 1024);
+
 
     private static final Logger log = LoggerFactory.getLogger(WorkerHandler.class);
 

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/worker/TestWorkerHandler.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/worker/TestWorkerHandler.java
@@ -1,0 +1,74 @@
+package io.openmessaging.benchmark.worker;
+
+import org.junit.Test;
+import org.junit.Assert.*;
+
+import io.openmessaging.benchmark.worker.WorkerHandler;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+import org.HdrHistogram.Histogram;
+
+
+public class TestWorkerHandler {
+
+
+    /**
+     * Create a random histogram and insert the given number of samples.
+     */
+    private Histogram randomHisto(int samples) {
+        Random r = new Random(0xBADBEEF);
+        Histogram h = new org.HdrHistogram.Histogram(5);
+        for (int i = 0; i < samples; i++) {
+            h.recordValue(r.nextInt(10000000));
+        }
+
+        return h;
+    }
+
+    byte[] serializeRandomHisto(int samples, int initialBufferSize) throws Exception {
+        ByteBuffer inbuffer = ByteBuffer.allocate(initialBufferSize);
+        Histogram inHisto = randomHisto(samples);
+        byte[] serialBytes = WorkerHandler.serializeHistogram(inHisto, inbuffer);
+
+        // check roundtrip
+        Histogram outHisto = Histogram.decodeFromCompressedByteBuffer(ByteBuffer.wrap(serialBytes), 0);
+        assertEquals(inHisto, outHisto);
+
+        return serialBytes;
+    }
+
+    @Test
+    public void testHistogram() throws Exception {
+
+        // in the worker it's 1 MB but it takes a while to make a histogram that big
+        final int BUF_SIZE = 1002;
+
+        int samples = 300;
+
+        // we do an exponential search to fit the crossover point where we need to grow the buffer
+        while (true) {
+            byte[] serialBytes = serializeRandomHisto(samples, BUF_SIZE);
+            // System.out.println("Samples: " + samples + ", histogram size: " + serialBytes.length);
+            if (serialBytes.length >= BUF_SIZE) {
+                break;
+            }
+            samples *= 1.05;
+        }
+
+        // then walk backwards across the point linearly with increment of 1 to check the boundary
+        // carefully
+        while (true) {
+            samples--;
+            byte[] serialBytes = serializeRandomHisto(samples, BUF_SIZE);
+            // System.out.println("Samples: " + samples + ", histogram size: " + serialBytes.length);
+            if (serialBytes.length < BUF_SIZE - 10) {
+                break;
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
When we serialize a histogram to a byte array, the intermediate
ByteBuffer that we pass may be too small which may result in silent
truncation of the encoded histogram.

This will manifest on the driver side as a decoding failure.

This change detects this case and grows the buffer by a
factor of 2 until it fits.

Fixes https://github.com/openmessaging/benchmark/issues/369.