### PR TITLE
Convert the deployment directory into a Maven module.

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,13 @@
+# OpenMessaging Benchmark Framework Helm Chart
+
+Requires having `helm` available in your current `$PATH`.
+
+```sh
+mvn helm:package
+```
+
+If running from the parent directory:
+
+```sh
+mvn helm:package -pl deployment
+```

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -1,0 +1,61 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>messaging-benchmark</artifactId>
+        <groupId>io.openmessaging.benchmark</groupId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>messaging-benchmark-helm</artifactId>
+
+    <name>Open Messaging Benchmark Helm Chart</name>
+    <packaging>pom</packaging>
+
+    <properties>
+        <docker.organization>docker.redpanda.com/redpandadata</docker.organization>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.openmessaging.benchmark</groupId>
+            <artifactId>package</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>bin</classifier>
+            <type>tar.gz</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kokuwa.maven</groupId>
+            <artifactId>helm-maven-plugin</artifactId>
+            <version>6.13.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.kokuwa.maven</groupId>
+                <artifactId>helm-maven-plugin</artifactId>
+                <configuration>
+                    <chartDirectory>${project.basedir}/kubernetes/helm/benchmark</chartDirectory>
+                    <chartVersion>${project.version}</chartVersion>
+                    <useLocalHelmBinary>true</useLocalHelmBinary>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
 		<module>driver-jms</module>
 		<module>driver-redis</module>
 		<module>package</module>
+		<module>deployment</module>
 		<module>docker</module>
 		<module>driver-kop</module>
 	</modules>


### PR DESCRIPTION
Wires in a Maven plugin for building the Helm chart into a tarball. Currently requires having a local install of `helm` as it's not clear if the plugin supports non-x86/amd64 systems when it comes to auto-downloading Helm binaries. (It wasn't working on my linux/arm64 host.)