### PR TITLE
Prevent runtime OOMs by having driver and worker JVMs pre-touch heap memory

### DIFF
--- a/bin/benchmark
+++ b/bin/benchmark
@@ -40,7 +40,7 @@ then
     HEAP_OPTS="-Xms4G -Xmx4G"
 fi
 
-JVM_MEM="${HEAP_OPTS} -XX:+UseG1GC"
+JVM_MEM="${HEAP_OPTS} -XX:+UseG1GC -XX:+AlwaysPreTouch"
 JVM_GC_LOG=" -XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime  -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=64m  -Xloggc:/dev/shm/benchmark-client-gc_%p.log"
 
 java -server -cp $CLASSPATH $JAVA_OPTS $JVM_MEM io.openmessaging.benchmark.Benchmark $*

--- a/bin/benchmark-worker
+++ b/bin/benchmark-worker
@@ -34,7 +34,7 @@ fi
 KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=0.0.0.0 -Djava.net.preferIPv4Stack=true"
 KAFKA_OPTS="${KAFKA_OPTS:--javaagent:/opt/benchmark/jmx_prometheus_javaagent-0.13.0.jar=9090:/opt/benchmark/metrics.yml}"
 
-JVM_MEM="${HEAP_OPTS} -XX:+UseG1GC"
-JVM_GC_LOG=" -XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=64m  -Xloggc:/dev/shm/benchmark-client-gc_%p.log"
+JVM_MEM="${HEAP_OPTS} -XX:+UseG1GC -XX:+AlwaysPreTouch"
+JVM_GC_LOG="-XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=64m -Xloggc:/dev/shm/benchmark-client-gc_%p.log"
 
 exec java -server $KAFKA_JMX_OPTS -cp $CLASSPATH $JAVA_OPTS $JVM_MEM $KAFKA_OPTS io.openmessaging.benchmark.worker.BenchmarkWorker $*


### PR DESCRIPTION
This is a trick I've used in other Java apps that are expected to utilize all the heap they're provided. It adds a small delay to startup, but should fault in virtual memory to back the JVM heap. This removes the chance of fatal OOM events when the JVM needs to grow the heap or cause a page fault at runtime.