### PR TITLE
Avoid scheduling OMB components on nodes running Redpanda

### DIFF
--- a/deployment/kubernetes/helm/benchmark/templates/benchmark-worker.yaml
+++ b/deployment/kubernetes/helm/benchmark/templates/benchmark-worker.yaml
@@ -17,8 +17,8 @@ kind: StatefulSet
 metadata:
   name: {{ .Release.Name }}-worker
   labels:
-    app: {{ .Release.Name }}
-    component: worker
+    app.kubernetes.io/app: {{ .Release.Name }}
+    app.kubernetes.io/component: omb-worker
 spec:
   serviceName: {{ .Release.Name }}-worker
   {{- if lt (int .Values.workers.replicaCount) 2 }}
@@ -39,6 +39,16 @@ spec:
       {{- with .Values.image.imagePullSecrets }}
       imagePullSecrets: {{ toYaml . | nindent 8}}
       {{- end }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - {{ .Values.redpanda.name | default "redpanda" }}-statefulset
       containers:
         - name: {{ .Release.Name }}-worker
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"

--- a/deployment/kubernetes/helm/benchmark/templates/benchmark.yaml
+++ b/deployment/kubernetes/helm/benchmark/templates/benchmark.yaml
@@ -17,12 +17,32 @@ kind: Pod
 metadata:
   name: {{ .Release.Name }}-driver
   labels:
-    app: {{ .Release.Name }}
-    role: driver
+    app.kubernetes.io/app: {{ .Release.Name }}
+    role: omb-driver
 spec:
   {{- with .Values.image.imagePullSecrets }}
   imagePullSecrets: {{ toYaml . | nindent 8}}
   {{- end }}
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                  - {{ .Values.redpanda.name | default "redpanda" }}-statefulset
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                    - omb-worker
+          weight: 100
   containers:
     - name: {{ .Release.Name }}-driver
       image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"

--- a/deployment/kubernetes/helm/benchmark/values.yaml
+++ b/deployment/kubernetes/helm/benchmark/values.yaml
@@ -27,6 +27,8 @@ image:
   #  - name: "secret name"
 
 redpanda:
+  # -- Name of the Redpanda cluster
+  name: redpanda
   brokers: "localhost:9092"
   tls:
     enabled: false

--- a/deployment/kubernetes/helm/benchmark/values.yaml
+++ b/deployment/kubernetes/helm/benchmark/values.yaml
@@ -92,7 +92,7 @@ workers:
   # -- Number of OMB Worker pods to deploy in the StatefulSet. (OMB requires a minimum of 2.)
   replicaCount: 2
   # -- Number of cpus to request for a Worker pod.
-  cpuCores: 2
+  cpuCores: 1
   memory:
     # -- JVM heap size (note: must use JVM heap values, not k8s memory sizes)
     heap: 1756m


### PR DESCRIPTION
We shouldn't schedule the OMB workers or driver on nodes that have Redpanda broker pods scheduled.

Ideally, we wouldn't schedule the driver on the same node as the workers.