### PR TITLE
Refactor the Docker image and how the benchmark scripts are invoked

### DIFF
--- a/bin/benchmark
+++ b/bin/benchmark
@@ -43,5 +43,12 @@ fi
 JVM_MEM="${HEAP_OPTS} -XX:+UseG1GC -XX:+AlwaysPreTouch"
 JVM_GC_LOG=" -XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime  -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=64m  -Xloggc:/dev/shm/benchmark-client-gc_%p.log"
 
-JAVA_HOME="${JAVA_HOME:-/opt/java/openjdk}"
-"${JAVA_HOME}/bin/java" -server -cp $CLASSPATH $JAVA_OPTS $JVM_MEM io.openmessaging.benchmark.Benchmark $*
+# To help execution in Docker images, lean on JAVA_HOME to find java.
+if [ -z "${JAVA_HOME}" ]
+  JAVA_EXE=java
+  echo 'Assuming java is in $PATH.' > /dev/stderr
+else
+  JAVA_EXE="${JAVA_HOME}/bin/java"
+  echo "Using java from ${JAVA_EXT}" >/dev/stderr
+fi
+"${JAVA_EXE}" -server -cp $CLASSPATH $JAVA_OPTS $JVM_MEM io.openmessaging.benchmark.Benchmark $*

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -35,8 +35,7 @@ else
     CLASSPATH=${DIR}/benchmark-framework/target/classes:`cat ${DIR}/benchmark-framework/target/classpath.txt`
 fi
 
-if [ -z "$HEAP_OPTS" ]
-then
+if [ -z "$HEAP_OPTS" ]; then
     HEAP_OPTS="-Xms4G -Xmx4G"
 fi
 
@@ -44,11 +43,11 @@ JVM_MEM="${HEAP_OPTS} -XX:+UseG1GC -XX:+AlwaysPreTouch"
 JVM_GC_LOG=" -XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime  -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=64m  -Xloggc:/dev/shm/benchmark-client-gc_%p.log"
 
 # To help execution in Docker images, lean on JAVA_HOME to find java.
-if [ -z "${JAVA_HOME}" ]
+if [ -z "${JAVA_HOME}" ]; then
   JAVA_EXE=java
   echo 'Assuming java is in $PATH.' > /dev/stderr
 else
   JAVA_EXE="${JAVA_HOME}/bin/java"
-  echo "Using java from ${JAVA_EXT}" >/dev/stderr
+  echo "Using java from: ${JAVA_EXE}" > /dev/stderr
 fi
 "${JAVA_EXE}" -server -cp $CLASSPATH $JAVA_OPTS $JVM_MEM io.openmessaging.benchmark.Benchmark $*

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -43,4 +43,5 @@ fi
 JVM_MEM="${HEAP_OPTS} -XX:+UseG1GC -XX:+AlwaysPreTouch"
 JVM_GC_LOG=" -XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime  -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=64m  -Xloggc:/dev/shm/benchmark-client-gc_%p.log"
 
-java -server -cp $CLASSPATH $JAVA_OPTS $JVM_MEM io.openmessaging.benchmark.Benchmark $*
+JAVA_HOME="${JAVA_HOME:-/opt/java/openjdk}"
+"${JAVA_HOME}/bin/java" -server -cp $CLASSPATH $JAVA_OPTS $JVM_MEM io.openmessaging.benchmark.Benchmark $*

--- a/bin/benchmark-worker
+++ b/bin/benchmark-worker
@@ -26,8 +26,7 @@ if [ -f ${LOG4J_CONFIG} ]; then
 	JAVA_OPTS="-DDlog4j.configurationFile=${LOG4J_CONFIG}"
 fi
 
-if [ -z "$HEAP_OPTS" ]
-then
+if [ -z "$HEAP_OPTS" ]; then
     HEAP_OPTS="-Xms4G -Xmx8G"
 fi
 
@@ -38,12 +37,12 @@ JVM_MEM="${HEAP_OPTS} -XX:+UseG1GC -XX:+AlwaysPreTouch"
 JVM_GC_LOG="-XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=64m -Xloggc:/dev/shm/benchmark-client-gc_%p.log"
 
 # To help execution in Docker images, lean on JAVA_HOME to find java.
-if [ -z "${JAVA_HOME}" ]
+if [ -z "${JAVA_HOME}" ]; then
   JAVA_EXE=java
   echo 'Assuming java is in $PATH.' > /dev/stderr
 else
   JAVA_EXE="${JAVA_HOME}/bin/java"
-  echo "Using java from ${JAVA_EXT}" >/dev/stderr
+  echo "Using java from: ${JAVA_EXE}" > /dev/stderr
 fi
 exec "${JAVA_EXE}" -server $KAFKA_JMX_OPTS -cp $CLASSPATH $JAVA_OPTS $JVM_MEM $KAFKA_OPTS io.openmessaging.benchmark.worker.BenchmarkWorker $*
 

--- a/bin/benchmark-worker
+++ b/bin/benchmark-worker
@@ -37,6 +37,13 @@ KAFKA_OPTS="${KAFKA_OPTS:--javaagent:/opt/benchmark/jmx_prometheus_javaagent-0.1
 JVM_MEM="${HEAP_OPTS} -XX:+UseG1GC -XX:+AlwaysPreTouch"
 JVM_GC_LOG="-XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=64m -Xloggc:/dev/shm/benchmark-client-gc_%p.log"
 
-JAVA_HOME="${JAVA_HOME:-/opt/java/openjdk}"
-exec "${JAVA_HOME}/bin/java" -server $KAFKA_JMX_OPTS -cp $CLASSPATH $JAVA_OPTS $JVM_MEM $KAFKA_OPTS io.openmessaging.benchmark.worker.BenchmarkWorker $*
+# To help execution in Docker images, lean on JAVA_HOME to find java.
+if [ -z "${JAVA_HOME}" ]
+  JAVA_EXE=java
+  echo 'Assuming java is in $PATH.' > /dev/stderr
+else
+  JAVA_EXE="${JAVA_HOME}/bin/java"
+  echo "Using java from ${JAVA_EXT}" >/dev/stderr
+fi
+exec "${JAVA_EXE}" -server $KAFKA_JMX_OPTS -cp $CLASSPATH $JAVA_OPTS $JVM_MEM $KAFKA_OPTS io.openmessaging.benchmark.worker.BenchmarkWorker $*
 

--- a/bin/benchmark-worker
+++ b/bin/benchmark-worker
@@ -37,4 +37,6 @@ KAFKA_OPTS="${KAFKA_OPTS:--javaagent:/opt/benchmark/jmx_prometheus_javaagent-0.1
 JVM_MEM="${HEAP_OPTS} -XX:+UseG1GC -XX:+AlwaysPreTouch"
 JVM_GC_LOG="-XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=64m -Xloggc:/dev/shm/benchmark-client-gc_%p.log"
 
-exec java -server $KAFKA_JMX_OPTS -cp $CLASSPATH $JAVA_OPTS $JVM_MEM $KAFKA_OPTS io.openmessaging.benchmark.worker.BenchmarkWorker $*
+JAVA_HOME="${JAVA_HOME:-/opt/java/openjdk}"
+exec "${JAVA_HOME}/bin/java" -server $KAFKA_JMX_OPTS -cp $CLASSPATH $JAVA_OPTS $JVM_MEM $KAFKA_OPTS io.openmessaging.benchmark.worker.BenchmarkWorker $*
+

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,13 +1,30 @@
 # OpenMessaging Benchmark Framework Helm Chart
 
-Requires having `helm` available in your current `$PATH`.
+## Packaging
+
+To create a tarball of the Chart, you may need `helm` available in your current `$PATH`.
+
+If running from this module's directory:
 
 ```sh
-mvn helm:package
+$ mvn helm:package
 ```
 
-If running from the parent directory:
+If running from the parent project directory:
 
 ```sh
 mvn helm:package -pl deployment
 ```
+
+## Using the Helm Chart to run a Benchmark
+
+1. Make sure you've built, tagged, and pushed the Docker image. See the
+   [README.md](../docker/README.md) for how to build using Maven.
+2. Create and customize a `values.yaml` file based on the Chart's
+   [values.yaml](./kubernetes/helm/benchmark/values.yaml).
+3. Use `helm install` to deploy the chart. Once running, you should see
+   your driver pod _Running_ in your namespace.
+4. Use `kubectl attach -it -n <namespace> omb-driver` to connect to the
+   running shell interpreter.
+5. Once connected, run `./run.sh` to begin a test run.
+6. Output will appear as json files in `/rum/omb/` backed by a PV.

--- a/deployment/kubernetes/helm/benchmark/templates/benchmark-worker.yaml
+++ b/deployment/kubernetes/helm/benchmark/templates/benchmark-worker.yaml
@@ -51,10 +51,7 @@ spec:
             - name: HEAP_OPTS
               value: "-Xms{{ .Values.workers.memory.heap }} -Xmx{{ .Values.workers.memory.heap }}"
           {{- end }}
-          command: [ "sh", "-c" ]
-          args:
-            - >
-              bin/benchmark-worker
+          command: [ "/opt/benchmark/bin/benchmark-worker" ]
           ports:
             - containerPort: 8080
             - containerPort: 8081

--- a/deployment/kubernetes/helm/benchmark/templates/benchmark.yaml
+++ b/deployment/kubernetes/helm/benchmark/templates/benchmark.yaml
@@ -24,6 +24,8 @@ spec:
     - name: {{ .Release.Name }}-driver
       image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"
       imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
+      stdin: true
+      tty: true
       {{- if or .Values.driver.memory .Values.driver.cpuCores }}
       resources:
         {{- if .Values.driver.memory }}
@@ -50,12 +52,7 @@ spec:
         - name: HEAP_OPTS
           value: "-Xms{{ .Values.driver.memory.heap }} -Xmx{{ .Values.driver.memory.heap }}"
         {{- end }}
-      command: ["sh", "-c"]
-      args:
-        - >
-          echo 'bin/benchmark -o \"/run/omb/test-`date '+%Y-%m-%dT%H%M%S'`.json\" --drivers /etc/omb/driver.yaml --workers \"${WORKERS}\" /etc/omb/workload.yaml' > run.sh &&
-          chmod +x run.sh &&
-          tail -f /dev/null
+      command: ["bash"]
   volumes:
     - name: omb-config
       projected:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,8 +15,9 @@ FROM ${base.image}:${base.tag}
 
 ARG BENCHMARK_TARBALL
 ENV JMX_EXPORTER="/opt/benchmark/driver-redpanda/deploy/monitoring/jmx_exporter"
-ENV KAFKA_OPTS="-javaagent:${JMX_EXPORTER}/jmx_prometheus_javaagent-0.13.0.jar=9090:${JMX_EXPORTER}/metrics.yml"
-ENV PATH="${PATH}:/opt/benchmark/bin"
+ENV KAFKA_OPTS="-javaagent:${JMX_EXPORTER}/jmx_prometheus_javaagent-0.13.0.jar=9090:${JMX_EXPORTER}/metrics.yml" \
+    PATH="${PATH}:/opt/benchmark/bin" \
+    JAVA_HOME=/opt/java/openjdk
 
 WORKDIR /opt/benchmark
 ADD run.sh /opt/benchmark/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,16 +11,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-FROM ${base}
+FROM ${base.image}:${base.tag}
 
 ARG BENCHMARK_TARBALL
-ADD ${BENCHMARK_TARBALL} /
-
-RUN mv openmessaging-benchmark-* /opt/benchmark
-WORKDIR /opt/benchmark
-
 ENV JMX_EXPORTER="/opt/benchmark/driver-redpanda/deploy/monitoring/jmx_exporter"
 ENV KAFKA_OPTS="-javaagent:${JMX_EXPORTER}/jmx_prometheus_javaagent-0.13.0.jar=9090:${JMX_EXPORTER}/metrics.yml"
+ENV PATH="${PATH}:/opt/benchmark/bin"
 
-ENTRYPOINT [ "/bin/bash" ]
+WORKDIR /opt/benchmark
+ADD run.sh /opt/benchmark/
+
+# Adds an unpacks the tarball built by `mvn install`. Then moves files into the workdir.
+ADD ${BENCHMARK_TARBALL} /
+RUN mv /${docker.image}-${project.version}/* /opt/benchmark/ && \
+    rm -R "/${docker.image}-${project.version}"
+
+ENTRYPOINT [ "/bin/bash", "-c" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,10 +20,11 @@ ENV PATH="${PATH}:/opt/benchmark/bin"
 
 WORKDIR /opt/benchmark
 ADD run.sh /opt/benchmark/
+RUN chmod +x /opt/benchmark/run.sh
 
 # Adds an unpacks the tarball built by `mvn install`. Then moves files into the workdir.
-ADD ${BENCHMARK_TARBALL} /
-RUN mv /${docker.image}-${project.version}/* /opt/benchmark/ && \
-    rm -R "/${docker.image}-${project.version}"
+# N.b. uses a symlink instead of moving files to reduce Docker layer sizes.
+ADD ${BENCHMARK_TARBALL} /opt
+RUN ln -sf -t /opt/benchmark /opt/${docker.image}-${project.version}/*
 
 ENTRYPOINT [ "/bin/bash", "-c" ]

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -26,9 +26,12 @@
     <packaging>pom</packaging>
 
     <properties>
-        <base>eclipse-temurin:11-jdk</base>
+        <base.image>eclipse-temurin</base.image>
+        <base.tag>11-jdk</base.tag>
         <docker-maven.version>0.43.4</docker-maven.version>
         <docker.organization>docker.redpanda.com/redpandadata</docker.organization>
+        <docker.image>openmessaging-benchmark</docker.image>
+        <!-- n.b. docker.image must match the way the package module names the tarball contents. -->
     </properties>
 
     <dependencies>
@@ -51,7 +54,7 @@
                 <configuration>
                     <images>
                         <image>
-                            <name>${docker.organization}/openmessaging-benchmark</name>
+                            <name>${docker.organization}/${docker.image}</name>
                             <alias>dockerfile</alias>
                             <build>
                                 <tags>

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -15,6 +15,7 @@ fi
 
 /opt/benchmark/bin/benchmark \
   --output "${TEST_NAME}" \
-  --driver "${DRIVER}" \
+  --drivers "${DRIVER}" \
   --workers "${WORKERS}" \
-  "${WORKLOAD}"
+  "${WORKLOAD}" \
+  $*

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+################################################################
+# Start a new benchmark run.
+################################################################
+
+TEST_NAME="/run/omb/test-$(date '+%Y-%m-%dT%H%M%S').json"
+DRIVER="${DRIVER:-/etc/omb/driver.yaml}"
+WORKLOAD="${WORKLOAD:-/etc/omb/workload.yaml}"
+
+if [ -z "${WORKERS}" ]; then
+  echo "WORKERS environment variable not set!" > /dev/stderr;
+  echo "Check your environment and set it to the list of worker urls." > /dev/stderr;
+  exit 1;
+fi
+
+/opt/benchmark/bin/benchmark \
+  --output "${TEST_NAME}" \
+  --driver "${DRIVER}" \
+  --workers "${WORKERS}" \
+  "${WORKLOAD}"


### PR DESCRIPTION
I recently encountered some environments where the container image may have its `PATH` modified by the container runtime. This was causing problems running the driver and worker scripts that just call `java` as if it's in the `PATH`.

Additionally, there were issues invoking the entrypoint commands. This ditches the format and approach from upstream. There's no need for a pod that does `tail /dev/null` when k8s can let you explicitly request a tty and `stdin` attached. This means instead of:

```
$ kubectl exec -it -n ns pod/omb-driver -- bash
```

You do:

```
$ kubectl attach -it -n ns omb-driver
```

This gets you connected to the running `bash` process in the pod without having to spawn an additional shell.

While here, this also tweaks how the base image and tag are configured for Maven, breaking it into two parts, so the image and tag can be changed independently.