### PR TITLE
Prevent git clones on Windows from adding `\r` to shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docker/run.sh   text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
-docker/run.sh   text eol=lf
+bin/benchmark           text eol=lf
+bin/benchmark-worker    text eol=lf
+docker/run.sh           text eol=lf


### PR DESCRIPTION
A user that cloned the repo on Windows reported that the Docker image being built resulted in un-runnable benchmark scripts. Turns out that Git for Windows can default to substituting `\r\n` for `\n` for text files unless a `.gitattributes` file explicitly overrides this behavior.

This defines `.gitattributes` and explicitly lists the 3 scripts as text files that should not have line ending substitution performed. The only tradeoff is someone editing these files on Windows will need an editor that can detect and use the proper line endings, but this prevents the happy path (`clean`, `install`, `build:docker`) from resulting in a broken image.