### PR TITLE
Fixes and improvements from AKS testing.

### DIFF
--- a/deployment/kubernetes/helm/benchmark/templates/benchmark-worker.yaml
+++ b/deployment/kubernetes/helm/benchmark/templates/benchmark-worker.yaml
@@ -21,7 +21,10 @@ metadata:
     component: worker
 spec:
   serviceName: {{ .Release.Name }}-worker
-  replicas: {{ .Values.workers.replicaCount }}
+  {{- if lt (int .Values.workers.replicaCount) 2 }}
+  {{- fail "A minimum of 2 workers are required. Check 'workers.replicaCount'."}}
+  {{- end }}
+  replicas: {{ .Values.workers.replicaCount | int }}
   podManagementPolicy: Parallel
   selector:
     matchLabels:
@@ -33,29 +36,27 @@ spec:
         app: {{ .Release.Name }}
         component: worker
     spec:
+      {{- with .Values.image.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml . | nindent 8}}
+      {{- end }}
       containers:
         - name: {{ .Release.Name }}-worker
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
-          {{- if .Values.workers.memory}}
           resources:
             limits:
               memory: {{ .Values.workers.memory.container.max }}
-              cpu: {{ .Values.workers.cpuCores }}
             requests:
               memory: {{ .Values.workers.memory.container.min }}
-              cpu: {{ .Values.workers.cpuCores }}
-          {{- end }}
-          {{- if .Values.workers.memory.heap }}
+              cpu: {{ .Values.workers.cpuCores | default 1 }}
           env:
             - name: HEAP_OPTS
               value: "-Xms{{ .Values.workers.memory.heap }} -Xmx{{ .Values.workers.memory.heap }}"
-          {{- end }}
           command: [ "/opt/benchmark/bin/benchmark-worker" ]
           ports:
             - containerPort: 8080
             - containerPort: 8081
-      {{- if and .Values.redpanda.tls.enabled .Values.redpanda.tls.caSecretRef }}
+      {{- if and .Values.redpanda.tls.enabled .Values.redpanda.tls.caSecretRef.name }}
           volumeMounts:
             - name: omb-ca
               mountPath: /opt/omb-ca

--- a/deployment/kubernetes/helm/benchmark/templates/benchmark.yaml
+++ b/deployment/kubernetes/helm/benchmark/templates/benchmark.yaml
@@ -20,26 +20,25 @@ metadata:
     app: {{ .Release.Name }}
     role: driver
 spec:
+  {{- with .Values.image.imagePullSecrets }}
+  imagePullSecrets: {{ toYaml . | nindent 8}}
+  {{- end }}
   containers:
     - name: {{ .Release.Name }}-driver
       image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"
       imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
       stdin: true
       tty: true
-      {{- if or .Values.driver.memory .Values.driver.cpuCores }}
       resources:
-        {{- if .Values.driver.memory }}
         limits:
           memory: {{ .Values.driver.memory.container.max }}
-        {{- end }}
         requests:
           {{- if .Values.driver.memory }}
           memory: {{ .Values.driver.memory.container.min | default .Values.driver.memory.container.max }}
           {{- end }}
           {{- if .Values.driver.cpuCores }}
-          cpu: {{ .Values.driver.cpuCores | default 2 }}
+          cpu: {{ .Values.driver.cpuCores | default 1 }}
           {{- end }}
-      {{- end }}
       volumeMounts:
         - name: omb-config
           mountPath: /etc/omb
@@ -67,7 +66,7 @@ spec:
     - name: omb-results
       {{- if .Values.driver.storage.persistentVolume.enabled }}
       persistentVolumeClaim:
-        claimName: omb-results-pvc
+        claimName: {{ .Release.Name }}-results-pvc
       {{- else if .Values.driver.storage.hostPath }}
       hostPath:
         path: {{ .Values.driver.storage.hostPath | quote }}

--- a/deployment/kubernetes/helm/benchmark/templates/driverConfig.yaml
+++ b/deployment/kubernetes/helm/benchmark/templates/driverConfig.yaml
@@ -32,7 +32,7 @@ data:
       {{- if .Values.redpanda.sasl.username }}
       sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username={{ .Values.redpanda.sasl.username | quote }} password={{ .Values.redpanda.sasl.password | quote }};
       {{- end }}
-      {{- if .Values.redpanda.tls.enabled }}
+      {{- if and .Values.redpanda.tls.enabled .Values.redpanda.tls.caSecretRef.name }}
       ssl.truststore.type=PEM
       ssl.truststore.location=/opt/omb-ca/{{ .Values.redpanda.tls.caSecretRef.key }}
       {{- end}}

--- a/deployment/kubernetes/helm/benchmark/values.yaml
+++ b/deployment/kubernetes/helm/benchmark/values.yaml
@@ -22,17 +22,26 @@ image:
   repository: docker.redpanda.com/openmessaging-benchmark/openmessaging-benchmark
   tag: latest
   pullPolicy: Always
+  # -- List of references to image pull secrets.
+  imagePullSecrets: []
+  #  - name: "secret name"
 
 redpanda:
   brokers: "localhost:9092"
   tls:
     enabled: false
+    # -- Reference to a k8s secret containing a trusted CA root certificate.
     caSecretRef:
-      name: redpanda-default-root-certificate
+      # -- Name of the k8s secret.
+      name: "" # redpanda-default-root-certificate
+      # -- Name of the key that contains the contents of the PEM-formatted CA root certificate.
       key: ca.crt
   sasl:
-    username: omb
+    # -- SASL username.
+    username: ""
+    # -- SASL password.
     password: ""
+    # -- SASL Mechanism. Supported values are: PLAIN, SCRAM-SHA-256, and SCRAM-SHA-512.
     mechanism: SCRAM-SHA-256
 
 # -- OMB Driver settings.
@@ -46,7 +55,7 @@ driver:
   # -- Kafka Request timeout
   requestTimeoutMs: 30000
   # -- Number of cpus to request for the driver.
-  cpuCores: 2
+  cpuCores: 1
   # -- Pod memory resource requests.
   memory:
     # -- JVM heap size (note: must use JVM heap values, not k8s memory sizes)
@@ -72,9 +81,9 @@ driver:
       # GKE, AWS & OpenStack).
       storageClass: ""
       # -- Additional labels to apply to the created PersistentVolumeClaims.
-      labels: { }
+      labels: {}
       # -- Additional annotations to apply to the created PersistentVolumeClaims.
-      annotations: { }
+      annotations: {}
 
 # -- OMB Worker settings.
 workers:


### PR DESCRIPTION
- Check for "name" key in caSecretRef, not caSecretRef itself.
- Refactor better defaults in values.yaml.
- Validate worker replica count defaults.
- Fix pvc name to use .Release.Name.