### PR TITLE
Enable multi-platform Docker builds (linux/amd64, linux/arm64)

### DIFF
--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -30,6 +30,7 @@
         <base.tag>11-jdk</base.tag>
         <docker-maven.version>0.43.4</docker-maven.version>
         <docker.organization>docker.redpanda.com/redpandadata</docker.organization>
+        <docker.platforms>linux/amd64,linux/arm64</docker.platforms>
         <docker.image>openmessaging-benchmark</docker.image>
         <!-- n.b. docker.image must match the way the package module names the tarball contents. -->
     </properties>
@@ -61,6 +62,11 @@
                                     <tag>latest</tag>
                                     <tag>${project.version}</tag>
                                 </tags>
+                                <buildx>
+                                    <platforms>
+                                        <platform>${docker.platforms}</platform>
+                                    </platforms>
+                                </buildx>
                                 <args>
                                     <BENCHMARK_TARBALL>target/package-${project.version}-bin.tar.gz</BENCHMARK_TARBALL>
                                 </args>


### PR DESCRIPTION
Updates the `docker-maven-plugin` to allow building Docker images for both `linux/amd64` and `linux/arm64`. This means to build and push for both platforms, it's a simple:

```
$ mvn docker:push -pl docker -Ddocker.organization=<my-dockerhub-acct>
```

Building for a single platform is possible by overriding `docker.platforms`:

```
$ mvn docker:build -pl docker -Ddocker.platforms=linux/amd64
```
