### PR TITLE
Fix TLS-enabled check in security protocol builder template logic.

### DIFF
--- a/deployment/kubernetes/helm/benchmark/templates/_helpers.tpl
+++ b/deployment/kubernetes/helm/benchmark/templates/_helpers.tpl
@@ -47,7 +47,7 @@ http://{{ $name }}-worker-{{ $index0 }}.{{ $name }}-worker:8080{{ if ne $index1 
 Identify the security protocol from the driver settings.
 */}}
 {{- define "security.protocol" -}}
-{{- if .Values.redpanda.tls -}}
+{{- if .Values.redpanda.tls.enabled -}}
   {{- if .Values.redpanda.sasl.username -}}
 SASL_SSL
   {{- else -}}


### PR DESCRIPTION
My original logic was flawed and results in not being able to generate a `SASL_PLAINTEXT` setting required for some Apache Kafka environments.