### PR TITLE
Use more auto-adjusting histograms

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/CumulativeLatencies.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/CumulativeLatencies.java
@@ -22,18 +22,18 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 public class CumulativeLatencies {
 
     @JsonIgnore
-    public Histogram publishLatency = new Histogram(TimeUnit.SECONDS.toMicros(60), 5);
+    public Histogram publishLatency = new Histogram(5);
     public byte[] publishLatencyBytes;
 
     @JsonIgnore
-    public Histogram publishDelayLatency = new Histogram(TimeUnit.SECONDS.toMicros(60), 5);
+    public Histogram publishDelayLatency = new Histogram(5);
     public byte[] publishDelayLatencyBytes;
 
     @JsonIgnore
-    public Histogram endToEndLatency = new Histogram(TimeUnit.HOURS.toMicros(12), 5);
+    public Histogram endToEndLatency = new Histogram(5);
     public byte[] endToEndLatencyBytes;
 
     @JsonIgnore
-    public Histogram scheduleLatency = new Histogram(TimeUnit.SECONDS.toMicros(60), 5);
+    public Histogram scheduleLatency = new Histogram(5);
     public byte[] scheduleLatencyBytes;
 }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/PeriodStats.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/PeriodStats.java
@@ -41,7 +41,7 @@ public class PeriodStats {
     public byte[] publishDelayLatencyBytes;
 
     @JsonIgnore
-    public Histogram endToEndLatency = new Histogram(TimeUnit.HOURS.toMicros(12), 5);
+    public Histogram endToEndLatency = new Histogram(5);
     public byte[] endToEndLatencyBytes;
 
     @JsonIgnore


### PR DESCRIPTION
This is a follow on to 95732ddd17b38509e7aacc0f06ab7e552cd10b9a.

This makes also the CumulativeLatencies histograms be auto-adjusting since they can fail in the same way. See the other commit for details.