### PR TITLE
Worker logging

### DIFF
--- a/bin/benchmark
+++ b/bin/benchmark
@@ -45,9 +45,9 @@ JVM_GC_LOG=" -XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime  -XX:+UseGCL
 # To help execution in Docker images, lean on JAVA_HOME to find java.
 if [ -z "${JAVA_HOME}" ]; then
   JAVA_EXE=java
-  echo 'Assuming java is in $PATH.' > /dev/stderr
+  echo "Assuming java is in \$PATH. Memory options: $JVM_MEM" > /dev/stderr
 else
   JAVA_EXE="${JAVA_HOME}/bin/java"
-  echo "Using java from: ${JAVA_EXE}" > /dev/stderr
+  echo "Using java from: ${JAVA_EXE}. Memory options: $JVM_MEM" > /dev/stderr
 fi
 "${JAVA_EXE}" -server -cp $CLASSPATH $JAVA_OPTS $JVM_MEM io.openmessaging.benchmark.Benchmark $*

--- a/bin/benchmark-worker
+++ b/bin/benchmark-worker
@@ -39,10 +39,10 @@ JVM_GC_LOG="-XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime -XX:+UseGCLog
 # To help execution in Docker images, lean on JAVA_HOME to find java.
 if [ -z "${JAVA_HOME}" ]; then
   JAVA_EXE=java
-  echo 'Assuming java is in $PATH.' > /dev/stderr
+  echo "Assuming java is in \$PATH. Memory options: $JVM_MEM" > /dev/stderr
 else
   JAVA_EXE="${JAVA_HOME}/bin/java"
-  echo "Using java from: ${JAVA_EXE}" > /dev/stderr
+  echo "Using java from: ${JAVA_EXE}. Memory options: $JVM_MEM" > /dev/stderr
 fi
 exec "${JAVA_EXE}" -server $KAFKA_JMX_OPTS -cp $CLASSPATH $JAVA_OPTS $JVM_MEM $KAFKA_OPTS io.openmessaging.benchmark.worker.BenchmarkWorker $*
 


### PR DESCRIPTION
The way worker nodes work in OMB is that there is a Worker facade
which hides wether there is a single LocalWorker or distributed workers
across multiple hosts. We collect all the statistics back to the
primary node (the one running bin/benchmark) and then log there, but
these log lines always reflect the aggregate statistics for all
workers.

When diagnosing performance issues it is useful to see the metrics for
individual workers as well, since correlated slowdowns imply something
different than uncorrelated ones (correlated slowdowns are highly
unlikely to be caused by a client/worker effect since they are on
independent hosts).

This change logs similar latency information to the primary node, on
each worker, at the same frequency as the primary node (specifically,
it logs when the primary node queries for stats). Since nodes are
either producers or consumers but not both, some stats will be zero
on workers (e.g., consume rate will be zero on producer nodes). All
worker nodes report 0 for backlog since that needs to be calculated by
correlating sent/recv from both consumers and producers.