### PR TITLE
Fail on unknown properties

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
@@ -242,10 +242,6 @@ public class Benchmark {
     private static final ObjectMapper tolerantMapper = new ObjectMapper(new YAMLFactory())
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
-    static {
-        mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
-    }
-
     private static final ObjectWriter writer = new ObjectMapper().writerWithDefaultPrettyPrinter();
 
     private static final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss");

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
@@ -184,7 +184,7 @@ public class Benchmark {
                     try {
                         String beginTime = dateFormat.format(new Date());
                         File driverConfigFile = new File(driverConfig);
-                        DriverConfiguration driverConfiguration = mapper.readValue(driverConfigFile,
+                        DriverConfiguration driverConfiguration = tolerantMapper.readValue(driverConfigFile,
                                 DriverConfiguration.class);
                         log.info("--------------- WORKLOAD : {} --- DRIVER : {}---------------", workload.name,
                                 driverConfiguration.name);
@@ -235,8 +235,12 @@ public class Benchmark {
         System.exit(success ? 0 : 1);
     }
 
-    private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory())
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+
+    // jackson mapper which allows unknown properties, which we need for driver config, since
+    // drivers config has arbitrary driver-specific properties
+    private static final ObjectMapper tolerantMapper = new ObjectMapper(new YAMLFactory())
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     static {
         mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/KeyDistributorType.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/KeyDistributorType.java
@@ -13,17 +13,14 @@
  */
 package io.openmessaging.benchmark.utils.distributor;
 
-import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
-
 public enum KeyDistributorType {
-    @JsonEnumDefaultValue
     /**
      * Key distributor that returns null keys to have default publish semantics
      */
     NO_KEY,
 
     /**
-     * Genarate a finite number of "keys" and cycle through them in round-robin fashion
+     * Generate a finite number of "keys" and cycle through them in round-robin fashion
      */
     KEY_ROUND_ROBIN,
 


### PR DESCRIPTION
Currently we allow unknown properties in the workload file, so something like a typo will be silently accepted.

This occurs because we explicitly configure the jackson mapper to allow unknown properties (the default is not to allow them), which is likely because we re-use the same mapper object to deserialize the driver file, which does need to pass through arbitrary properties to the driver. However, the other mapper uses seem like they'd be better off with a strict mapper.

This changes splits the mappers: using a unknown-properties-allowed mapper only for the driver config file.