### PR TITLE
driver-redpanda: set JVM memory limits based on host memory

### DIFF
--- a/driver-redpanda/deploy/deploy.yaml
+++ b/driver-redpanda/deploy/deploy.yaml
@@ -386,7 +386,7 @@
       lineinfile:
         dest: /opt/benchmark/bin/benchmark-worker
         regexp: "^JVM_MEM="
-        line: 'JVM_MEM="-Xms50G -Xmx50G -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:+ParallelRefProcEnabled -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=12 -XX:ConcGCThreads=12 -XX:+DisableExplicitGC -XX:-ResizePLAB"'
+        line: 'JVM_MEM="-Xms{{ (ansible_memfree_mb - 1024)|int }}G -Xmx50G -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:+ParallelRefProcEnabled -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=12 -XX:ConcGCThreads=12 -XX:+DisableExplicitGC -XX:-ResizePLAB"'
     - name: Configure memory
       lineinfile:
         dest: /opt/benchmark/bin/benchmark


### PR DESCRIPTION
Fixes issues where the benchmark worker java processes take more memory than the client instance and keep getting hit by the OOM killer / causing SSH connections to get hit by the OOM killer.

Not sure if `-Xmx50G` should be made dynamic too?