### PR TITLE
Parallelize producer probes in LocalWorker. Add logging.

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
@@ -225,10 +225,11 @@ public class LocalWorker implements Worker, ConsumerCallback {
             .map(p -> p.sendAsync(Optional.of("key"), new byte[24]))
             .mapToInt(f -> {
                 try {
-                    f.get(30, TimeUnit.SECONDS); // if we take longer than 30s to probe one producer, something is wrong!
+                    f.get(1, TimeUnit.MINUTES); // if we take longer than 1m to probe, something is wrong!
                     totalMessagesSent.increment();
                 } catch (Exception e) {
                     log.error("error probing producer", e);
+                    return 0;
                 }
                 return 1;
             })
@@ -236,6 +237,7 @@ public class LocalWorker implements Worker, ConsumerCallback {
         // Check our work and report success rate.
         if (cnt != producers.size()) {
             log.warn("only probed {}/{} producers", cnt, producers.size());
+            throw new IOException("unable to probe all producers");
         }
     }
 


### PR DESCRIPTION
When running tests with a large number of producers per OMB client machine (>100), there's a noticeable startup delay. It turns out that, while futures were being used, they were only being advanced serially.

While here, improve some logging in this area.

For reference, starting a test with 960 producers can take ~5 minutes to perform the probing. Eventually one will hit a hardcoded http client timeout in OMB as the text executor/orchestrator times out waiting for the worker to reply to the HTTP request triggering the probe.