### PR TITLE
Send POSTs to workers in parallel

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
@@ -285,7 +285,22 @@ public class DistributedWorkersEnsemble implements Worker {
      * Send a request to multiple hosts and wait for all responses
      */
     private void sendPost(List<String> hosts, String path, byte[] body) {
-        FutureUtil.waitForAll(hosts.stream().map(w -> sendPost(w, path, body)).collect(toList())).join();
+        int cnt = hosts
+            .parallelStream()
+            .mapToInt(host -> {
+                try {
+                    sendPost(host, path, body).get(); // HTTP client has a timeout, so no timeout here.
+                } catch (Exception e) {
+                    // TODO: raise certain exceptions here?
+                    log.error("failed to send POST to {}{}", host, path, e);
+                    return 0;
+                }
+                return 1;
+            })
+            .sum();
+        if (cnt != hosts.size()) {
+            throw new RuntimeException("failed to successfully POST to all hosts");
+        }
     }
 
     private CompletableFuture<Void> sendPost(String host, String path, byte[] body) {


### PR DESCRIPTION
There's no reason to do this serially. Plus, it removes dependency on a Pulsar class in lieu of native Java features.