### PR TITLE
Probe topic partitions using a null key to distribute work.

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
@@ -223,7 +223,7 @@ public class LocalWorker implements Worker, ConsumerCallback {
         log.info("beginning probe of {} producers", producers.size());
         int cnt = producers
             .parallelStream()
-            .map(p -> p.sendAsync(Optional.of("key"), new byte[24]))
+            .map(p -> p.sendAsync(Optional.empty(), new byte[24]))
             .mapToInt(f -> {
                 try {
                     f.get(1, TimeUnit.MINUTES); // if we take longer than 1m to probe, something is wrong!


### PR DESCRIPTION
When a test starts up and "probes" a large number of producers in parallel, they currently all try writing to the same topic partition. This puts all the stress on a single Redpanda shard. Using a `null` key helps distribute this load across partitions and, consequently, across shards.