### PR TITLE
Prevent NPE when the `stop-all` call is issued to borked workers

### DIFF
--- a/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/RedpandaBenchmarkDriver.java
+++ b/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/RedpandaBenchmarkDriver.java
@@ -208,11 +208,17 @@ public class RedpandaBenchmarkDriver implements BenchmarkDriver {
         for (BenchmarkProducer producer : producers) {
             producer.close();
         }
+        producers.clear();
 
         for (BenchmarkConsumer consumer : consumers) {
             consumer.close();
         }
-        admin.close();
+        consumers.clear();
+
+        if (admin != null) {
+            admin.close();
+            admin = null;
+        }
     }
 
     private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory())


### PR DESCRIPTION
While troubleshooting an issue with some OMB workers, it seems the driver instances were getting into a strange state where they were partially initialized. Consequently, the admin client reference was `null`, and starting a new test would trigger NPEs on all the workers.

This puts a little bit of safety around that area and makes sure we actually clean out state so a new test run can properly re-initialize things.