### PR TITLE
Don't wait for consumers if there are none

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
@@ -71,6 +71,24 @@ public class Workload {
     public int sampleRateMillis = 10000;
     public int testDurationMinutes;
 
+
+    /**
+     * Return true if existing topics are being used or false if the workload will create its own topics.
+     */
+    public boolean isUsingExistingTopics() {
+        return !existingTopicList.isEmpty() || !existingConsumeTopicList.isEmpty() || !existingProduceTopicList.isEmpty();
+    }
+    /**
+     * Return the total number of consumers defined in the workload.
+     */
+    public int getConsumerCount() {
+        int topicCount = topics;
+        if (isUsingExistingTopics()) {
+            topicCount = existingTopicList.size() + existingConsumeTopicList.size();
+        }
+        return topicCount * subscriptionsPerTopic * consumerPerSubscription;
+    }
+
     /**
      * Perform basic validation on the workload and throw an exception if
      * any invalid configuration is found.
@@ -86,7 +104,7 @@ public class Workload {
         checkNonNegative(producerRate, "producerRate");
         checkNonNegative(consumerBacklogSizeGB, "consumerBacklogSizeGB");
 
-        boolean usingExistingTopics = !existingTopicList.isEmpty() || !existingConsumeTopicList.isEmpty() || !existingProduceTopicList.isEmpty();
+        boolean usingExistingTopics = isUsingExistingTopics();
 
         if (topics > 0 && usingExistingTopics) {
             throw new RuntimeException(String.format(

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -155,6 +155,14 @@ public class WorkloadGenerator implements AutoCloseable {
     }
 
     private void ensureTopicsAreReady() throws IOException {
+
+        if (workload.getConsumerCount() == 0) {
+            // no consumers so the check below will always time out, so just
+            // short-circuit here
+            log.info("Not waiting for consumers because there are none");
+            return;
+        }
+
         log.info("Waiting for consumers to be ready");
         // This is work around the fact that there's no way to have a consumer ready in
         // Kafka without first publishing

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/TopicsInfo.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/TopicsInfo.java
@@ -71,8 +71,7 @@ public class TopicsInfo {
      */
     public static TopicsInfo fromWorkload(Workload w) {
         Preconditions.checkNotNull(w);
-        boolean usingExistingTopics = !w.existingTopicList.isEmpty() || !w.existingConsumeTopicList.isEmpty() || !w.existingProduceTopicList.isEmpty();
-        Preconditions.checkArgument(w.topics > 0 != usingExistingTopics);
+        Preconditions.checkArgument(w.topics > 0 != w.isUsingExistingTopics());
         if (w.topics > 0) {
             return new TopicsInfo(w.topics, w.partitionsPerTopic);
         } else {


### PR DESCRIPTION
It is sometimes useful to run a test without consumers, e.g., to test the produce latency in isolation. OMB supports this: just set subcriptionsPerTopic to 0 (or consumers per subscription to 0, etc).

However, in zero consumer mode each benchmark is delayed for a minute while we wait for consumers to be "ready", which means that they have received the probe message we sent out. Since there are no consumers, this will never happen.

After this change we skip this check when there are no consumers.