### PR TITLE
RedpandaDriver: fix (again) topic deletion race

### DIFF
--- a/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/RedpandaBenchmarkDriver.java
+++ b/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/RedpandaBenchmarkDriver.java
@@ -31,6 +31,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.errors.UnknownTopicIdException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
@@ -103,7 +104,7 @@ public class RedpandaBenchmarkDriver implements BenchmarkDriver {
                     deletes.all().get();
                 }
             } catch (ExecutionException e) {
-                if (e.getCause() instanceof UnknownTopicOrPartitionException) {
+                if (e.getCause() instanceof UnknownTopicOrPartitionException || e.getCause() instanceof UnknownTopicIdException) {
                     log.warn("Topic(s) appeared to be deleted already (race condition)");
                 } else {
                     throw new IOException("Could not delete previous topics", e);


### PR DESCRIPTION
Every worker will have initializeDriver called and there we implement the 'reset' functionality which deletes all existing topics created by OMB from prior runs. *All* producers do this more or less simultaneously because there currently no mechanism to single out one producer to do that work. So if you have 2 or more producers they are racing to delete the same topics.

We already catch the expected exception type which occurs when a deleter loses the race and just log, but it turns out that some Kafka implementations can also throw UnknownTopicIdException which is similar. So catch and log in that case too.