### PR TITLE
Fix that zstd is not linking properly for redpanda-driver

### DIFF
--- a/driver-redpanda/pom.xml
+++ b/driver-redpanda/pom.xml
@@ -51,6 +51,11 @@
 			<artifactId>kafka-clients</artifactId>
 			<version>3.3.1</version>
 		</dependency>
+		<dependency>
+			<groupId>com.github.luben</groupId>
+			<artifactId>zstd-jni</artifactId>
+ 			<version>1.5.6-3</version>
+		</dependency>
 
 		<!-- Custom build -->
 		<!-- <dependency>


### PR DESCRIPTION
driver-redpanda cannot use zstd compression because it fails to find the class. Adding this dependency explicitly ensures that we have a copy of the required classes for the Redpanda driver.