### PR TITLE
Added very simple transactions benchmark

### DIFF
--- a/driver-redpanda/redpanda-ack-all-tx-2.yaml
+++ b/driver-redpanda/redpanda-ack-all-tx-2.yaml
@@ -1,0 +1,38 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Redpanda-exactly-once
+driverClass: io.openmessaging.benchmark.driver.redpanda.tx.RedpandaBenchmarkDriver
+
+# Kafka client-specific configuration
+replicationFactor: 3
+reset: true
+requestsPerTransaction: 2
+
+topicConfig: |
+
+commonConfig: |
+  bootstrap.servers=localhost:9092
+
+producerConfig: |
+  enable.idempotence=true
+  max.in.flight.requests.per.connection=1
+  retries=2147483647
+  acks=all
+  linger.ms=1
+  batch.size=131072
+
+consumerConfig: |
+  auto.offset.reset=earliest
+  enable.auto.commit=false

--- a/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/RedpandaBenchmarkDriverBase.java
+++ b/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/RedpandaBenchmarkDriverBase.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.driver.redpanda;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DeleteTopicsResult;
+import org.apache.kafka.clients.admin.ListTopicsOptions;
+import org.apache.kafka.clients.admin.ListTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.errors.UnknownTopicIdException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import io.openmessaging.benchmark.driver.BenchmarkConsumer;
+import io.openmessaging.benchmark.driver.BenchmarkDriver;
+import io.openmessaging.benchmark.driver.BenchmarkProducer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class RedpandaBenchmarkDriverBase implements BenchmarkDriver {
+
+    protected Config config;
+
+    protected List<BenchmarkProducer> producers = Collections.synchronizedList(new ArrayList<>());
+    protected List<BenchmarkConsumer> consumers = Collections.synchronizedList(new ArrayList<>());
+
+    protected Properties topicProperties;
+    protected Properties producerProperties;
+    protected Properties consumerProperties;
+
+    protected AdminClient admin;
+
+    @Override
+    public void initialize(File configurationFile, StatsLogger statsLogger) throws IOException {
+        config = mapper.readValue(configurationFile, Config.class);
+
+        Properties commonProperties = new Properties();
+        commonProperties.load(new StringReader(config.commonConfig));
+
+        producerProperties = new Properties();
+        commonProperties.forEach((key, value) -> producerProperties.put(key, value));
+        producerProperties.load(new StringReader(config.producerConfig));
+        producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        producerProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+
+        consumerProperties = new Properties();
+        commonProperties.forEach((key, value) -> consumerProperties.put(key, value));
+        consumerProperties.load(new StringReader(config.consumerConfig));
+        consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+
+        topicProperties = new Properties();
+        topicProperties.load(new StringReader(config.topicConfig));
+
+        admin = AdminClient.create(commonProperties);
+
+        if (config.reset) {
+            // List existing topics
+            ListTopicsResult result = admin.listTopics();
+            try {
+                // Delete all existing topics matching the prefix
+                String topicPrefix = getTopicNamePrefix();
+                Set<String> topicsToDelete = result.names().get().stream()
+                        .filter(topic -> topic.startsWith(topicPrefix))
+                        .collect(Collectors.toSet());
+
+                if (topicsToDelete.size() > 0) {
+                    DeleteTopicsResult deletes = admin.deleteTopics(topicsToDelete);
+                    deletes.all().get();
+                }
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof UnknownTopicOrPartitionException
+                        || e.getCause() instanceof UnknownTopicIdException) {
+                    log.warn("Topic(s) appeared to be deleted already (race condition)");
+                } else {
+                    throw new IOException("Could not delete previous topics", e);
+                }
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+                throw new IOException(e);
+            }
+        }
+    }
+
+    @Override
+    public String getTopicNamePrefix() {
+        return "test-topic";
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(RedpandaBenchmarkDriver.class);
+
+    protected <T> CompletableFuture<T> toCompletableFuture(final KafkaFuture<T> kafkaFuture) {
+        final CompletableFuture<T> wrappingFuture = new CompletableFuture<>();
+        kafkaFuture.whenComplete((value, throwable) -> {
+            if (throwable != null) {
+                wrappingFuture.completeExceptionally(throwable);
+            } else {
+                wrappingFuture.complete(value);
+            }
+        });
+        return wrappingFuture;
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Override
+    public CompletableFuture<Void> createTopic(String topic, int partitions) {
+        log.info("Creating a topic: {}, with {} partitions and replication of: {}",
+                topic, partitions, config.replicationFactor);
+        NewTopic newTopic = new NewTopic(topic, partitions, config.replicationFactor);
+        newTopic.configs(new HashMap<>((Map) topicProperties));
+        return toCompletableFuture(admin.createTopics(Arrays.asList(newTopic)).all());
+
+    }
+
+    @Override
+    public CompletableFuture<Boolean> validateTopicExists(String topicName) {
+        return toCompletableFuture(admin.listTopics(new ListTopicsOptions()).names())
+                .thenApply(names -> names.stream().anyMatch(topic -> topic.equals(topicName)));
+
+    }
+
+    @Override
+    public void close() throws Exception {
+        for (BenchmarkProducer producer : producers) {
+            producer.close();
+        }
+        producers.clear();
+
+        for (BenchmarkConsumer consumer : consumers) {
+            consumer.close();
+        }
+        consumers.clear();
+
+        if (admin != null) {
+            admin.close();
+            admin = null;
+        }
+    }
+
+    protected static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory())
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+}

--- a/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/tx/Config.java
+++ b/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/tx/Config.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.driver.redpanda.tx;
+
+public class Config extends io.openmessaging.benchmark.driver.redpanda.Config {
+    // A property controlling the number of messages sent in a single transaction.
+    // It controls the frequency of transaction requests. 
+    public short requestsPerTransaction;
+}

--- a/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/tx/RedpandaBenchmarkProducer.java
+++ b/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/tx/RedpandaBenchmarkProducer.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.driver.redpanda.tx;
+
+import io.openmessaging.benchmark.driver.BenchmarkProducer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.InvalidProducerEpochException;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.LongAdder;
+
+public class RedpandaBenchmarkProducer implements BenchmarkProducer {
+    final Logger logger = LoggerFactory.getLogger(RedpandaBenchmarkProducer.class);
+    private final KafkaProducer<String, byte[]> producer;
+    private final String topic;
+    private final int requestsPerTransaction;
+    private final LongAdder cnt = new LongAdder();
+
+    private enum ProducerState {
+        NEEDS_INIT,
+        NEEDS_COMMIT,
+        NEEDS_ABORT,
+        READY
+    }
+
+    private ProducerState state = ProducerState.NEEDS_INIT;
+
+    public RedpandaBenchmarkProducer(KafkaProducer<String, byte[]> producer, String topic,
+            int requestsPerTransaction) {
+
+        this.producer = producer;
+        this.topic = topic;
+
+        this.requestsPerTransaction = requestsPerTransaction;
+
+    }
+
+    @Override
+    public CompletableFuture<Void> sendAsync(Optional<String> key, byte[] payload) {
+        if (payload.length < 16 + 8) {
+            throw new RuntimeException();
+        }
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        try {
+            if (cnt.sum() == requestsPerTransaction) {
+                cnt.reset();
+                state = ProducerState.NEEDS_COMMIT;
+            }
+            switch (state) {
+                case READY:
+                    break;
+                case NEEDS_ABORT:
+                    logger.info("Aborting transaction");
+                    producer.abortTransaction();
+                    producer.beginTransaction();
+                    break;
+                case NEEDS_INIT:
+                    logger.info("Initializing producer transactions");
+                    producer.initTransactions();
+                    producer.beginTransaction();
+                    break;
+                case NEEDS_COMMIT:
+                    try {
+                        producer.commitTransaction();
+                    } catch (TimeoutException e) {
+                        // in case of commit timeout the commit has to be retried
+                        future.completeExceptionally(e);
+                        return future;
+                    }
+                    producer.beginTransaction();
+                    break;
+                default:
+                    break;
+            }
+            state = ProducerState.READY;
+
+            byte[] data = Arrays.copyOf(payload, payload.length);
+            ProducerRecord<String, byte[]> record = new ProducerRecord<String, byte[]>(topic, key.orElse(null), data);
+
+            cnt.increment();
+            producer.send(record, (metadata, exception) -> {
+                if (exception != null) {
+                    if (exception instanceof InvalidProducerEpochException) {
+                        state = ProducerState.NEEDS_ABORT;
+                    }
+                    future.completeExceptionally(exception);
+                } else {
+                    future.complete(null);
+                }
+            });
+        } catch (Exception e) {
+            state = ProducerState.NEEDS_ABORT;
+            future.completeExceptionally(e);
+        }
+
+        return future;
+    }
+
+    @Override
+    public void close() throws Exception {
+        producer.close();
+    }
+
+}


### PR DESCRIPTION
Added a simple Redpanda driver that leverages transactions. The producer produces to the partitions using atomic produce. The transaction is committed every configurable number of messages. This way the user can control the overhead of transaction related request in standard open messaging benchmark.