### PR TITLE
driver-redpanda: Fix incorrect consumer property initialization

### DIFF
--- a/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/RedpandaBenchmarkDriver.java
+++ b/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/RedpandaBenchmarkDriver.java
@@ -72,7 +72,8 @@ public class RedpandaBenchmarkDriver extends RedpandaBenchmarkDriverBase {
     @Override
     public CompletableFuture<BenchmarkConsumer> createConsumer(String topic, String subscriptionName,
             ConsumerCallback consumerCallback) {
-        Properties properties = new Properties(consumerProperties);
+        Properties properties = new Properties();
+        properties.putAll(consumerProperties);
         properties.put(ConsumerConfig.GROUP_ID_CONFIG, subscriptionName);
         KafkaConsumer<String, byte[]> kafkaConsumer = new KafkaConsumer<>(properties);
         try {

--- a/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/swarm/RedpandaBenchmarkDriver.java
+++ b/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/swarm/RedpandaBenchmarkDriver.java
@@ -74,7 +74,7 @@ public class RedpandaBenchmarkDriver extends RedpandaBenchmarkDriverBase {
     public CompletableFuture<BenchmarkConsumer> createConsumer(String topic, String subscriptionName,
             ConsumerCallback consumerCallback) {
         Properties properties = new Properties();
-        consumerProperties.forEach((key, value) -> properties.put(key, value));
+        properties.putAll(consumerProperties);
         properties.put(ConsumerConfig.GROUP_ID_CONFIG, nodeId.toString() + "-" + subscriptionName);
         KafkaConsumer<String, byte[]> kafkaConsumer = new KafkaConsumer<>(properties);
         try {

--- a/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/tx/RedpandaBenchmarkDriver.java
+++ b/driver-redpanda/src/main/java/io/openmessaging/benchmark/driver/redpanda/tx/RedpandaBenchmarkDriver.java
@@ -66,7 +66,7 @@ public class RedpandaBenchmarkDriver extends RedpandaBenchmarkDriverBase {
     public CompletableFuture<BenchmarkConsumer> createConsumer(String topic, String subscriptionName,
             ConsumerCallback consumerCallback) {
         Properties properties = new Properties();
-        consumerProperties.forEach((key, value) -> properties.put(key, value));
+        properties.putAll(consumerProperties);
         properties.put(ConsumerConfig.GROUP_ID_CONFIG, subscriptionName);
         KafkaConsumer<String, byte[]> kafkaConsumer = new KafkaConsumer<>(properties);
         try {


### PR DESCRIPTION
The standard driver was not actually setting all the consumer properties
because passing the properties to the constructor just sets the defaults
for `get` but doesn't actually set values to the keys.