### PR TITLE
fix zero-producer case

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
@@ -144,7 +144,9 @@ public class DistributedWorkersEnsemble implements Worker {
     @Override
     public void startLoad(ProducerWorkAssignment producerWorkAssignment) throws IOException {
         // Reduce the publish rate across all the brokers
-        producerWorkAssignment.publishRate /= numberOfUsedProducerWorkers;
+        if (numberOfUsedProducerWorkers != 0) {
+            producerWorkAssignment.publishRate /= numberOfUsedProducerWorkers;
+        }
         sendPost(producerWorkers, "/start-load", writer.writeValueAsBytes(producerWorkAssignment));
     }
 


### PR DESCRIPTION
It is valid to run a benchmark with 0 producers, e.g., by setting `producersPerTopic: 0`. This works already in local mode, but in distributed mode you get an exception about the rate being NaN or Inf.

This is due to a divide-by-zero in the step that distributes the work among all the local workers.