### PR TITLE
Isolate gcp terraform

### DIFF
--- a/driver-redpanda/deploy/ansible.cfg
+++ b/driver-redpanda/deploy/ansible.cfg
@@ -1,6 +1,5 @@
 [defaults]
 host_key_checking=false
-private_key_file=~/.ssh/redpanda_aws
 interpreter_python=auto
 inventory = hosts.ini
 pipelining = true

--- a/driver-redpanda/deploy/aws/provision-redpanda-aws.tf
+++ b/driver-redpanda/deploy/aws/provision-redpanda-aws.tf
@@ -15,6 +15,11 @@ provider "aws" {
 provider "random" {
 }
 
+variable "private_key_path" {
+  description = "Path to the private SSH key used for Ansible"
+  type        = string
+}
+
 variable "public_key_path" {
   description = <<DESCRIPTION
 Path to the SSH public key to be used for authentication.
@@ -280,7 +285,8 @@ resource "local_file" "hosts_ini" {
       control_public_ips   = aws_instance.client.*.public_ip
       control_private_ips  = aws_instance.client.*.private_ip
       instance_type	   = var.instance_types["redpanda"]
-      ssh_user              = "ubuntu"
+      ssh_user             = "ubuntu"
+      private_key_path     = var.private_key_path
     }
   )
   filename = "${path.module}/hosts.ini"

--- a/driver-redpanda/deploy/aws/terraform.tfvars.example
+++ b/driver-redpanda/deploy/aws/terraform.tfvars.example
@@ -1,4 +1,5 @@
-public_key_path = "~/.ssh/redpanda_aws.pub"
+public_key_path  = "~/.ssh/redpanda_aws.pub"
+private_key_path = "~/.ssh/redpanda_aws"
 
 region          = "us-west-2"
 # arm64 ubuntu focal

--- a/driver-redpanda/deploy/deploy.yaml
+++ b/driver-redpanda/deploy/deploy.yaml
@@ -469,7 +469,7 @@
     grafana_version: 9.5.14
     grafana_security:
       admin_user: admin
-      admin_password: "{{ grafana_admin_pass | default('enter_your_secure_password', true) }}"
+      admin_password: "{{ grafana_admin_pass | default('admin', true) }}"
     grafana_datasources:
     - name: prometheus
       type: prometheus

--- a/driver-redpanda/deploy/gcp/provision-redpanda-gcp.tf
+++ b/driver-redpanda/deploy/gcp/provision-redpanda-gcp.tf
@@ -117,7 +117,7 @@ resource "google_compute_firewall" "allow_redpanda" {
 
   allow {
     protocol = "tcp"
-    ports    = ["9092", "9644", "8081", "8082", "33145", "3000", "9090"] # Kafka API + Admin API + Prometheus/Grafana
+    ports    = ["9092", "9644", "8080", "8081", "8082", "33145", "3000", "9090"] # Kafka API + Admin API + Prometheus/Grafana
   }
 
   source_ranges = [var.subnet_cidr_range]

--- a/driver-redpanda/deploy/gcp/provision-redpanda-gcp.tf
+++ b/driver-redpanda/deploy/gcp/provision-redpanda-gcp.tf
@@ -1,6 +1,75 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.0"
+    }
+  }
+}
+
+
 provider "google" {
-  project     = var.project_name
+  #project     = var.project_name
   region      = var.region
+}
+
+provider "random" {
+}
+
+variable "private_key_path" {
+  description = "Path to the private SSH key used for Ansible"
+  type        = string
+}
+
+variable "public_key_path" {
+  description = <<DESCRIPTION
+Path to the SSH public key to be used for authentication.
+Ensure this keypair is added to your local SSH agent so provisioners can
+connect.
+
+Example: ~/.ssh/redpanda_gcp.pub
+DESCRIPTION
+  type = string
+}
+
+variable "subnet_cidr_range" {
+  type        = string
+  description = "CIDR range for Redpanda subnet"
+  default     = "10.10.0.0/16"
+}
+
+variable "instance_types" {
+  type = map(string)
+  default = {
+    redpanda = "n2-standard-8"
+    monitor  = "n2-standard-4"
+    client   = "n2-standard-16"
+  }
+}
+
+variable "num_instances" {
+  description = "Map of instance counts by role"
+  type        = map(number)
+  default     = {
+    redpanda = 3
+    client   = 4
+    monitor  = 1
+  }
+}
+
+variable "redpanda_disk_size_gb" {
+  type        = number
+  description = "Size (in GB) of the local NVMe disk for Redpanda.  Must be in 375GB increments."
+  default     = 375
+}
+
+data "http" "my_ip" {
+  url = "https://ipv4.icanhazip.com"
+}
+
+
+resource "random_id" "hash" {
+  byte_length = 8
 }
 
 resource "random_uuid" "cluster" {}
@@ -10,33 +79,77 @@ locals {
   deployment_id = random_uuid.cluster.result
 }
 
+
+# Create a new VPC
+resource "google_compute_network" "redpanda_vpc" {
+  name                    = "redpanda-vpc-${random_id.hash.hex}"
+  auto_create_subnetworks = false
+}
+
+
+# Create subnets
+resource "google_compute_subnetwork" "redpanda_subnet" {
+  name          = "redpanda-subnet-${random_id.hash.hex}"
+  ip_cidr_range = var.subnet_cidr_range
+  region        = var.region
+  network       = google_compute_network.redpanda_vpc.id
+}
+
+
+# Allow traffic on Redpanda, Prometheus, and Grafana ports
+resource "google_compute_firewall" "allow_ssh" {
+  name    = "allow-external-access"
+  network = google_compute_network.redpanda_vpc.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "3000", "9090"]
+  }
+
+  source_ranges = ["${chomp(data.http.my_ip.response_body)}/32"]
+}
+
+
+# Allow traffic on Redpanda, Prometheus, and Grafana ports
+resource "google_compute_firewall" "allow_redpanda" {
+  name    = "allow-redpanda"
+  network = google_compute_network.redpanda_vpc.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["9092", "9644", "8081", "8082", "33145", "3000", "9090"] # Kafka API + Admin API + Prometheus/Grafana
+  }
+
+  source_ranges = [var.subnet_cidr_range]
+}
+
+
+
 resource "google_compute_resource_policy" "redpanda-rp" {
   name   = "redpanda-rp"
   region = var.region
   group_placement_policy {
-    availability_domain_count = var.ha ? max(3, var.nodes) : 1
+    availability_domain_count = var.ha ? max(3, var.num_instances["redpanda"]) : 1
   }
   count = var.ha ? 1 : 0
 }
 
 resource "google_compute_instance" "redpanda" {
-  count             = var.nodes
+  count             = var.num_instances["redpanda"]
   name              = "rp-node-${count.index}-${local.deployment_id}"
   tags              = ["rp-cluster", "tf-deployment-${local.deployment_id}"]
   zone              = "${var.region}-${var.availability_zone[count.index % length(var.availability_zone)]}"
-  machine_type      = var.machine_type
+  machine_type      = var.instance_types["redpanda"]
   // GCP does not give you visibility nor control over which failure domain a resource has been placed into
   // (https://issuetracker.google.com/issues/256993209?pli=1). So the only way that we can guarantee that
   // specific nodes are in separate racks is to put them into entirely separate failure domains - basically one
   // broker per failure domain, and we are limited by the number of failure domains (at the moment 8).
-  resource_policies = (var.ha && var.nodes <= 8) ? [
+  resource_policies = (var.ha && var.num_instances["redpanda"] <= 8) ? [
     google_compute_resource_policy.redpanda-rp[0].id
   ] : null
 
   metadata = {
-    ssh-keys = <<KEYS
-${var.ssh_user}:${file(abspath(var.public_key_path))}
-KEYS
+    ssh-keys = "${var.ssh_user}:${file(var.public_key_path)}"
   }
 
   boot_disk {
@@ -46,7 +159,7 @@ KEYS
   }
 
   dynamic "scratch_disk" {
-    for_each = range(var.disks)
+    for_each = range(floor(var.redpanda_disk_size_gb / 375))
     content {
       // 375 GB local SSD drive.
       interface = "NVME"
@@ -54,7 +167,7 @@ KEYS
   }
 
   network_interface {
-    subnetwork = var.subnet
+    subnetwork = google_compute_subnetwork.redpanda_subnet.id
     access_config {
     }
   }
@@ -63,16 +176,14 @@ KEYS
 }
 
 resource "google_compute_instance" "monitor" {
-  count        = 1
+  count        = var.num_instances["monitor"]
   name         = "rp-monitor-${local.deployment_id}"
   tags         = ["rp-cluster", "tf-deployment-${local.deployment_id}"]
-  machine_type = var.monitor_machine_type
+  machine_type = var.instance_types["monitor"]
   zone         = "${var.region}-${var.availability_zone[0]}"
 
   metadata = {
-    ssh-keys = <<KEYS
-${var.ssh_user}:${file(abspath(var.public_key_path))}
-KEYS
+    ssh-keys = "${var.ssh_user}:${file(var.public_key_path)}"
   }
 
   boot_disk {
@@ -87,7 +198,7 @@ KEYS
   }
 
   network_interface {
-    subnetwork = var.subnet
+    subnetwork = google_compute_subnetwork.redpanda_subnet.id
     access_config {
     }
   }
@@ -96,16 +207,14 @@ KEYS
 }
 
 resource "google_compute_instance" "client" {
-  count        = var.client_nodes
+  count        = var.num_instances["client"]
   name         = "rp-client-${count.index}-${local.deployment_id}"
   tags         = ["rp-cluster", "tf-deployment-${local.deployment_id}"]
-  machine_type = var.client_machine_type
+  machine_type = var.instance_types["client"]
   zone         = "${var.region}-${var.availability_zone[count.index % length(var.availability_zone)]}"
 
   metadata = {
-    ssh-keys = <<KEYS
-${var.ssh_user}:${file(abspath(var.public_key_path))}
-KEYS
+    ssh-keys = "${var.ssh_user}:${file(var.public_key_path)}"
   }
 
   boot_disk {
@@ -123,12 +232,21 @@ KEYS
   }
 
   network_interface {
-    subnetwork = var.subnet
+    subnetwork = google_compute_subnetwork.redpanda_subnet.id
     access_config {
     }
   }
   labels = tomap(var.labels)
 }
+
+resource "google_compute_route" "internet_access" {
+  name              = "redpanda-default-route"
+  network           = google_compute_network.redpanda_vpc.name
+  dest_range        = "0.0.0.0/0"
+  next_hop_gateway  = "default-internet-gateway"
+  priority          = 1000
+}
+
 
 resource "google_compute_instance_group" "redpanda" {
   name      = "redpanda-group-${local.deployment_id}"
@@ -145,17 +263,18 @@ resource "google_compute_instance_group" "redpanda" {
 resource "local_file" "hosts_ini" {
   content = templatefile("${path.module}/../hosts_ini.tpl",
     {
-      redpanda_public_ips        = google_compute_instance.redpanda[*].network_interface.0.access_config.0.nat_ip
-      redpanda_private_ips       = google_compute_instance.redpanda[*].network_interface.0.network_ip
-      clients_public_ips         = google_compute_instance.client[*].network_interface.0.access_config.0.nat_ip
-      clients_private_ips        = google_compute_instance.client[*].network_interface.0.network_ip
-      control_public_ips         = google_compute_instance.client[*].network_interface.0.access_config.0.nat_ip
-      control_private_ips        = google_compute_instance.client[*].network_interface.0.network_ip
-      prometheus_host_public_ips = google_compute_instance.monitor[*].network_interface.0.access_config.0.nat_ip
-      prometheus_host_private_ips= google_compute_instance.monitor[*].network_interface.0.network_ip
-      ssh_user                   = var.ssh_user
-      instance_type              = var.machine_type
-    }
+      redpanda_public_ips         = google_compute_instance.redpanda[*].network_interface.0.access_config.0.nat_ip
+      redpanda_private_ips        = google_compute_instance.redpanda[*].network_interface.0.network_ip
+      clients_public_ips          = google_compute_instance.client[*].network_interface.0.access_config.0.nat_ip
+      clients_private_ips         = google_compute_instance.client[*].network_interface.0.network_ip
+      control_public_ips          = google_compute_instance.client[*].network_interface.0.access_config.0.nat_ip
+      control_private_ips         = google_compute_instance.client[*].network_interface.0.network_ip
+      prometheus_host_public_ips  = google_compute_instance.monitor[*].network_interface.0.access_config.0.nat_ip
+      prometheus_host_private_ips = google_compute_instance.monitor[*].network_interface.0.network_ip
+      instance_type               = var.instance_types["redpanda"]
+      ssh_user                    = var.ssh_user
+      private_key_path            = var.private_key_path 
+   }
   )
   filename = "${path.module}/hosts.ini"
 }
@@ -195,30 +314,10 @@ variable "instance_group_name" {
   default     = "redpanda-group"
 }
 
-variable "subnet" {
-  description = "The name of the existing subnet where the machines will be deployed"
-}
-
-variable "project_name" {
-  description = "The project name on GCP."
-}
-
-variable "nodes" {
-  description = "The number of nodes to deploy."
-  type        = number
-  default     = "3"
-}
-
 variable "ha" {
   description = "Whether to use placement groups to create an HA topology"
   type        = bool
   default     = false
-}
-
-variable "client_nodes" {
-  description = "The number of clients to deploy."
-  type        = number
-  default     = "4"
 }
 
 variable "disks" {
@@ -239,24 +338,6 @@ variable "image" {
   default = "ubuntu-os-cloud/ubuntu-2204-lts"
 }
 
-variable machine_type {
-  # List of available machines per region/ zone:
-  # https://cloud.google.com/compute/docs/regions-zones#available
-  default = "n2-standard-8"
-}
-
-variable monitor_machine_type {
-  default = "n2-standard-4"
-}
-
-variable client_machine_type {
-  default = "n2-standard-16"
-}
-
-variable "public_key_path" {
-  description = "The ssh key."
-}
-
 variable "ssh_user" {
   description = "The ssh user. Must match the one in the public ssh key's comments."
 }
@@ -268,7 +349,7 @@ variable "enable_monitoring" {
 variable "labels" {
   description = "passthrough of GCP labels"
   default     = {
-    "purpose"      = "redpanda-cluster"
+    "purpose"      = "redpanda-cluster-via-omb"
     "created-with" = "terraform"
   }
 }

--- a/driver-redpanda/deploy/gcp/terraform.tfvars.example
+++ b/driver-redpanda/deploy/gcp/terraform.tfvars.example
@@ -1,0 +1,22 @@
+public_key_path  = "~/.ssh/redpanda_gcp.pub"
+private_key_path = "~/.ssh/redpanda_gcp"
+
+ssh_user         = "ubuntu"
+region           = "us-central1"
+
+subnet_cidr_range      = "10.10.0.0/16"
+redpanda_disk_size_gb  = 750    # must be in 375GB increments
+
+instance_types = {
+  "redpanda"      = "n2d-standard-8"
+  "client"        = "n2-standard-16"
+  "monitor"       = "n2-standard-4"
+}
+
+# client instances may need to be larger than redpanda broker count
+# to provide enough message volume for testing
+num_instances = {
+  "client"     = 4
+  "redpanda"   = 3
+  "monitor"    = 1
+}

--- a/driver-redpanda/deploy/hosts_ini.tpl
+++ b/driver-redpanda/deploy/hosts_ini.tpl
@@ -18,3 +18,4 @@ ${ ip } ansible_user=${ ssh_user } ansible_become=True private_ip=${prometheus_h
 
 [all:vars]
 instance_type=${instance_type}
+ansible_ssh_private_key_file=${private_key_path}


### PR DESCRIPTION
Added network creation to the GCP terraform (previously required you to have a VPC, security, etc.   Aligned the tfvars for AWS & GCP so they operate more or less the same, tweaked some ansible stuff to be cloud-agnostic.

Made the README more cloud-agnostic as well.

Azure remains untouched, and in an unknown state.