### PR TITLE
Change node_exporter vars to dictionary

### DIFF
--- a/driver-redpanda/deploy/deploy.yaml
+++ b/driver-redpanda/deploy/deploy.yaml
@@ -429,12 +429,11 @@
   roles:
   - geerlingguy.node_exporter
   vars:
-  - node_exporter_enabled_collectors: [ntp]
-  - dist_architecture: {
-      "aarch64": "arm64",
+    node_exporter_enabled_collectors: "ntp"
+    dist_architecture:
+      "aarch64": "arm64"
       "x86_64": "amd64"
-    }
-  - node_exporter_arch: "{{ [ansible_architecture] | map('extract', dist_architecture) | first }}"
+    node_exporter_arch: "{{ [ansible_architecture] | map('extract', dist_architecture) | first }}"
   tags:
     - node_exporter
 


### PR DESCRIPTION
Existing code will fail to execute with "ERROR! Vars in a Play must be specified as a dictionary."