### PR TITLE
Corrected syntax on Node Exporter install 

### DIFF
--- a/driver-redpanda/deploy/deploy.yaml
+++ b/driver-redpanda/deploy/deploy.yaml
@@ -426,15 +426,13 @@
 # Install the monitoring stack
 - name: Install Node Exporter
   hosts: redpanda, client
-  roles:
-  - geerlingguy.node_exporter
+  gather_facts: true
   vars:
-  - node_exporter_enabled_collectors: [ntp]
-  - dist_architecture: {
-      "aarch64": "arm64",
-      "x86_64": "amd64"
-    }
-  - node_exporter_arch: "{{ [ansible_architecture] | map('extract', dist_architecture) | first }}"
+    node_exporter_enabled_collectors: [ntp]
+    dist_architecture:
+      aarch64: arm64
+      x86_64: amd64
+    node_exporter_arch: "{{ dist_architecture[ansible_architecture] | string }}"
   tags:
     - node_exporter
 


### PR DESCRIPTION
The syntax prevented the playbook from deploying.  This corrects that such that the repo can work as-is again.