### PR TITLE
Added compression codecs for snappy, lz4, and zstd

### DIFF
--- a/driver-redpanda/README.md
+++ b/driver-redpanda/README.md
@@ -53,6 +53,8 @@
         sudo bin/benchmark -d driver-redpanda/redpanda-ack-all-group-linger-10ms.yaml \
             driver-redpanda/deploy/workloads/1-topic-100-partitions-1kb-4-producers-500k-rate.yaml
 
+   Note that compression codecs are available for snappy, gzip, lz4, and zstd
+
 ## Generating charts
 
 Once you have ran a benchmark, a json file will be generated in the data directory. You can use `bin/generate_charts.py` to generate a a visual representation of this data.

--- a/driver-redpanda/pom.xml
+++ b/driver-redpanda/pom.xml
@@ -50,12 +50,42 @@
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
 			<version>3.3.1</version>
+		        <exclusions>
+		          <exclusion>
+		            <groupId>org.lz4</groupId>
+		            <artifactId>lz4-java</artifactId>
+		          </exclusion>
+		        </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.github.luben</groupId>
 			<artifactId>zstd-jni</artifactId>
  			<version>1.5.6-3</version>
 		</dependency>
+
+
+                <!-- lz4 -->
+		<dependency>
+		  <groupId>org.lz4</groupId>
+		  <artifactId>lz4-java</artifactId>
+		  <version>1.8.0</version>
+		</dependency>
+
+		<!-- Snappy -->
+		<dependency>
+		  <groupId>org.xerial.snappy</groupId>
+		  <artifactId>snappy-java</artifactId>
+		  <version>1.1.10.5</version>
+		</dependency>
+
+		<!-- Zstd -->
+		<dependency>
+		  <groupId>com.github.luben</groupId>
+		  <artifactId>zstd-jni</artifactId>
+		  <version>1.5.6-3</version>
+		</dependency>
+
+
 
 		<!-- Custom build -->
 		<!-- <dependency>


### PR DESCRIPTION
The only compression available was gzip, so support was added for lz4, snappy, and zstd.

To make use, in the producer section of the driver file:

```yaml
producerConfig: |
  acks=1
  linger.ms=2
  batch.size=16384
  max.in.flight=2
  compression.type=zstd
```

