### PR TITLE
AWS peering

### DIFF
--- a/driver-redpanda/deploy/terraform.tfvars.example
+++ b/driver-redpanda/deploy/terraform.tfvars.example
@@ -7,8 +7,8 @@ benchmark_vpc_cidr    = "10.0.0.0/16"
 benchmark_subnet_cidr = "10.0.0.0/24"
 
 # Optional VPC Peering to existing VPC
-byoc_vpc_id   = "vpc-05c7835713d6a7641"    # use null if no peering is required
-byoc_vpc_cidr = "10.40.0.0/16"             # use null if no peering is required
+byoc_vpc_id   = null  # example: "vpc-05c7835713d6a7641" //use null if no peering is required
+byoc_vpc_cidr = null  # example: "10.99.0.0/16"          //use null if no peering is required
 
 
 # arm64 ubuntu focal

--- a/driver-redpanda/deploy/terraform.tfvars.example
+++ b/driver-redpanda/deploy/terraform.tfvars.example
@@ -1,11 +1,14 @@
 public_key_path = "~/.ssh/redpanda_aws.pub"
 
-
 region            = "us-west-2"
 availability_zone = "us-west-2a"
 
 benchmark_vpc_cidr    = "10.0.0.0/16"
 benchmark_subnet_cidr = "10.0.0.0/24"
+
+# Optional VPC Peering to existing VPC
+byoc_vpc_id   = "vpc-05c7835713d6a7641"    # use null if no peering is required
+byoc_vpc_cidr = "10.40.0.0/16"             # use null if no peering is required
 
 
 # arm64 ubuntu focal


### PR DESCRIPTION
If you're planning to benchmark against an existing private BYOC cluster, you'll probably want to peer the benchmark VPC to your BYOC VPC.   If you supply your vpc id & cidr in tfvars, terraform will peer the newly created benchmark VPC to your BYOC VPC. 

If you had been doing this manually, you had to first delete the peering and the routes before you could terraform destroy.

Supplying `null` for the peering variables to bypass the peering logic.