### PR TITLE
Bump kafka version to latest v3 release

### DIFF
--- a/driver-kafka/pom.xml
+++ b/driver-kafka/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
-			<version>3.3.1</version>
+			<version>3.9.1</version>
 		</dependency>
 	</dependencies>
 

--- a/driver-redpanda/pom.xml
+++ b/driver-redpanda/pom.xml
@@ -49,7 +49,8 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
-			<version>3.3.1</version>
+			<!-- Note that the kafka-client version here should match the version in driver-kafka/pom.xml -->
+			<version>3.9.1</version>
 		        <exclusions>
 		          <exclusion>
 		            <groupId>org.lz4</groupId>


### PR DESCRIPTION
appears to quiet down this error at the beginning of the test run

```
[Producer clientId=producer-6] Resetting the last seen epoch of partition test-topic-p6-tF_k-0000-0 to 1 since the associated topicId changed from null to 5lH8EkTCScmFpWmNCvz7Dw
```

See https://issues.apache.org/jira/browse/KAFKA-16986