### PR TITLE
feat: add GCP Terraform deployment support

### DIFF
--- a/driver-redpanda/deploy/gcp/README.md
+++ b/driver-redpanda/deploy/gcp/README.md
@@ -1,0 +1,84 @@
+# Redpanda Benchmark — GCP Deployment
+
+Deploy Redpanda brokers and OMB benchmark clients on GCP using Terraform + Ansible.
+
+## Prerequisites
+
+1. [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.0
+2. [gcloud CLI](https://cloud.google.com/sdk/docs/install) authenticated:
+   ```bash
+   gcloud auth application-default login
+   ```
+3. Compute API enabled in your project:
+   ```bash
+   gcloud services enable compute.googleapis.com --project=<your-project>
+   ```
+4. An SSH key pair:
+   ```bash
+   ssh-keygen -t rsa -f ~/.ssh/redpanda_gcp
+   ```
+
+## Usage
+
+```bash
+cd driver-redpanda/deploy/gcp
+
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars — set project_name, ssh_user, public_key_path at minimum
+
+terraform init
+terraform apply
+```
+
+Run Ansible from the `deploy/` directory (one level up — `hosts.ini` is written there by Terraform).
+`ansible.cfg` hardcodes `~/.ssh/redpanda_aws`, so pass your GCP key explicitly with `--private-key`.
+
+**Standalone Redpanda cluster:**
+```bash
+cd ..
+ansible-playbook deploy.yaml -i hosts.ini --private-key ~/.ssh/redpanda_gcp
+```
+
+**Against an existing BYOC/Dedicated cluster** (set `num_instances.redpanda = 0` in tfvars):
+```bash
+cd ..
+ansible-playbook deploy.yaml -i hosts.ini \
+  --private-key ~/.ssh/redpanda_gcp \
+  --ask-become-pass \
+  -e "tls_enabled=true sasl_enabled=true sasl_username=<user> sasl_password=<password>" \
+  -e "bootstrapServers=<seed-host>:9092"
+```
+
+> `--ask-become-pass` is needed when running Ansible from a local Mac (the playbook has tasks requiring sudo). Omit it when running from a cloud VM as root.
+
+## VPC Peering (optional)
+
+Set `byoc_vpc_name` in `terraform.tfvars` to peer the benchmark network with an existing
+BYOC network. `terraform apply` creates peering in both directions automatically.
+
+### IAM requirement
+
+Your credentials need `compute.networks.addPeering` on both the benchmark project and the
+BYOC project. Grant it with:
+
+```bash
+gcloud projects add-iam-policy-binding <byoc-project> \
+  --member="user:<your-email>" \
+  --role="roles/compute.networkAdmin"
+```
+
+### Fallback: manual peering
+
+If you cannot obtain IAM access to the BYOC project (e.g. it is managed by Redpanda),
+create the return peering manually after `terraform apply`:
+
+```bash
+BENCHMARK_NETWORK=$(terraform output -raw benchmark_network_name)
+BENCHMARK_PROJECT=<your-benchmark-project>
+
+gcloud compute networks peerings create rp-byoc-to-benchmark \
+  --network=<your-byoc-network> \
+  --peer-project=$BENCHMARK_PROJECT \
+  --peer-network=$BENCHMARK_NETWORK \
+  --project=<byoc-project>
+```

--- a/driver-redpanda/deploy/gcp/provision-redpanda-gcp.tf
+++ b/driver-redpanda/deploy/gcp/provision-redpanda-gcp.tf
@@ -1,42 +1,129 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    random = {
+      version = "~> 3.4.3"
+    }
+    http = {
+      version = "~> 3.0"
+    }
+    local = {
+      version = "~> 2.0"
+    }
+  }
+}
+
 provider "google" {
-  project     = var.project_name
-  region      = var.region
+  project = var.project_name
+  region  = var.region
+}
+
+data "http" "myip" {
+  url = "http://ipv4.icanhazip.com"
 }
 
 resource "random_uuid" "cluster" {}
 
 locals {
-  uuid          = random_uuid.cluster.result
-  deployment_id = random_uuid.cluster.result
+  deployment_id    = random_uuid.cluster.result
+  ssh_key_metadata = "${var.ssh_user}:${file(pathexpand(var.public_key_path))}"
 }
 
-resource "google_compute_resource_policy" "redpanda-rp" {
-  name   = "redpanda-rp"
+resource "google_compute_network" "benchmark" {
+  name                    = "rp-benchmark-${local.deployment_id}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "benchmark" {
+  name          = "rp-benchmark-subnet-${local.deployment_id}"
+  ip_cidr_range = var.benchmark_subnet_cidr
+  region        = var.region
+  network       = google_compute_network.benchmark.self_link
+}
+
+resource "google_compute_firewall" "internal_icmp" {
+  name    = "rp-benchmark-internal-icmp-${local.deployment_id}"
+  network = google_compute_network.benchmark.name
+  allow {
+    protocol = "icmp"
+  }
+  source_ranges = [var.benchmark_subnet_cidr]
+  target_tags   = ["rp-cluster"]
+}
+
+resource "google_compute_firewall" "internal_tcp" {
+  name    = "rp-benchmark-internal-tcp-${local.deployment_id}"
+  network = google_compute_network.benchmark.name
+  allow {
+    protocol = "tcp"
+    ports    = ["0-65535"]
+  }
+  source_ranges = [var.benchmark_subnet_cidr]
+  target_tags   = ["rp-cluster"]
+}
+
+resource "google_compute_firewall" "deployer_access" {
+  name    = "rp-benchmark-deployer-${local.deployment_id}"
+  network = google_compute_network.benchmark.name
+  allow {
+    protocol = "tcp"
+    ports    = ["0-65535"]
+  }
+  source_ranges = ["${chomp(data.http.myip.response_body)}/32"]
+  target_tags   = ["rp-cluster"]
+}
+
+resource "google_compute_firewall" "monitoring" {
+  name    = "rp-benchmark-monitoring-${local.deployment_id}"
+  network = google_compute_network.benchmark.name
+  allow {
+    protocol = "tcp"
+    ports    = ["9090", "3000"]
+  }
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["rp-cluster"]
+}
+
+resource "google_compute_network_peering" "benchmark_to_byoc" {
+  count        = var.byoc_vpc_name != null ? 1 : 0
+  name         = "rp-benchmark-to-byoc-${local.deployment_id}"
+  network      = google_compute_network.benchmark.self_link
+  peer_network = "https://www.googleapis.com/compute/v1/projects/${coalesce(var.gcp_project, var.project_name)}/global/networks/${var.byoc_vpc_name}"
+}
+
+resource "google_compute_network_peering" "byoc_to_benchmark" {
+  count        = var.byoc_vpc_name != null ? 1 : 0
+  name         = "rp-byoc-to-benchmark-${local.deployment_id}"
+  network      = "https://www.googleapis.com/compute/v1/projects/${coalesce(var.gcp_project, var.project_name)}/global/networks/${var.byoc_vpc_name}"
+  peer_network = google_compute_network.benchmark.self_link
+  depends_on   = [google_compute_network_peering.benchmark_to_byoc]
+}
+
+# GCP does not give visibility or control over which failure domain a resource is placed into
+# (https://issuetracker.google.com/issues/256993209). Separate failure domains are used to
+# guarantee separate racks. GCP caps availability_domain_count at 8.
+resource "google_compute_resource_policy" "redpanda" {
+  name   = "rp-placement-${local.deployment_id}"
   region = var.region
   group_placement_policy {
-    availability_domain_count = var.ha ? max(3, var.nodes) : 1
+    availability_domain_count = var.ha ? min(8, max(3, var.num_instances["redpanda"])) : 1
   }
   count = var.ha ? 1 : 0
 }
 
 resource "google_compute_instance" "redpanda" {
-  count             = var.nodes
+  count             = var.num_instances["redpanda"]
   name              = "rp-node-${count.index}-${local.deployment_id}"
   tags              = ["rp-cluster", "tf-deployment-${local.deployment_id}"]
-  zone              = "${var.region}-${var.availability_zone[count.index % length(var.availability_zone)]}"
-  machine_type      = var.machine_type
-  // GCP does not give you visibility nor control over which failure domain a resource has been placed into
-  // (https://issuetracker.google.com/issues/256993209?pli=1). So the only way that we can guarantee that
-  // specific nodes are in separate racks is to put them into entirely separate failure domains - basically one
-  // broker per failure domain, and we are limited by the number of failure domains (at the moment 8).
-  resource_policies = (var.ha && var.nodes <= 8) ? [
-    google_compute_resource_policy.redpanda-rp[0].id
-  ] : null
+  zone              = var.availability_zone[count.index % length(var.availability_zone)]
+  machine_type      = var.instance_types["redpanda"]
+  resource_policies = (var.ha && var.num_instances["redpanda"] <= 8) ? [google_compute_resource_policy.redpanda[0].id] : null
 
   metadata = {
-    ssh-keys = <<KEYS
-${var.ssh_user}:${file(abspath(var.public_key_path))}
-KEYS
+    ssh-keys = local.ssh_key_metadata
   }
 
   boot_disk {
@@ -48,31 +135,27 @@ KEYS
   dynamic "scratch_disk" {
     for_each = range(var.disks)
     content {
-      // 375 GB local SSD drive.
       interface = "NVME"
     }
   }
 
   network_interface {
-    subnetwork = var.subnet
-    access_config {
-    }
+    subnetwork = google_compute_subnetwork.benchmark.self_link
+    access_config {}
   }
 
   labels = tomap(var.labels)
 }
 
 resource "google_compute_instance" "monitor" {
-  count        = 1
-  name         = "rp-monitor-${local.deployment_id}"
+  count        = var.num_instances["prometheus"]
+  name         = "rp-monitor-${count.index}-${local.deployment_id}"
   tags         = ["rp-cluster", "tf-deployment-${local.deployment_id}"]
-  machine_type = var.monitor_machine_type
-  zone         = "${var.region}-${var.availability_zone[0]}"
+  machine_type = var.instance_types["prometheus"]
+  zone         = var.availability_zone[0]
 
   metadata = {
-    ssh-keys = <<KEYS
-${var.ssh_user}:${file(abspath(var.public_key_path))}
-KEYS
+    ssh-keys = local.ssh_key_metadata
   }
 
   boot_disk {
@@ -82,30 +165,26 @@ KEYS
   }
 
   scratch_disk {
-    // 375 GB local SSD drive.
     interface = "NVME"
   }
 
   network_interface {
-    subnetwork = var.subnet
-    access_config {
-    }
+    subnetwork = google_compute_subnetwork.benchmark.self_link
+    access_config {}
   }
 
   labels = tomap(var.labels)
 }
 
 resource "google_compute_instance" "client" {
-  count        = var.client_nodes
+  count        = var.num_instances["client"]
   name         = "rp-client-${count.index}-${local.deployment_id}"
   tags         = ["rp-cluster", "tf-deployment-${local.deployment_id}"]
-  machine_type = var.client_machine_type
-  zone         = "${var.region}-${var.availability_zone[count.index % length(var.availability_zone)]}"
+  machine_type = var.instance_types["client"]
+  zone         = var.availability_zone[count.index % length(var.availability_zone)]
 
   metadata = {
-    ssh-keys = <<KEYS
-${var.ssh_user}:${file(abspath(var.public_key_path))}
-KEYS
+    ssh-keys = local.ssh_key_metadata
   }
 
   boot_disk {
@@ -117,46 +196,42 @@ KEYS
   dynamic "scratch_disk" {
     for_each = range(var.client_disks)
     content {
-      // 375 GB local SSD drive.
       interface = "NVME"
     }
   }
 
   network_interface {
-    subnetwork = var.subnet
-    access_config {
-    }
+    subnetwork = google_compute_subnetwork.benchmark.self_link
+    access_config {}
   }
+
   labels = tomap(var.labels)
 }
 
 resource "google_compute_instance_group" "redpanda" {
-  name      = "redpanda-group-${local.deployment_id}"
-  count     = length(var.availability_zone)
-  zone      = "${var.region}-${var.availability_zone[count.index]}"
+  count = length(var.availability_zone)
+  name  = "redpanda-group-${local.deployment_id}-${count.index}"
+  zone  = var.availability_zone[count.index]
   instances = tolist(concat(
-    [for i in google_compute_instance.redpanda.* : i.self_link if i.zone == "${var.region}-${var.availability_zone[count.index]}"],
-    [for i in google_compute_instance.monitor.* : i.self_link if i.zone == "${var.region}-${var.availability_zone[count.index]}"],
-    [for i in google_compute_instance.client.* : i.self_link if i.zone == "${var.region}-${var.availability_zone[count.index]}"]
-   )
-  )
+    [for i in google_compute_instance.redpanda[*] : i.self_link if i.zone == var.availability_zone[count.index]],
+    [for i in google_compute_instance.monitor[*] : i.self_link if i.zone == var.availability_zone[count.index]],
+    [for i in google_compute_instance.client[*] : i.self_link if i.zone == var.availability_zone[count.index]]
+  ))
 }
 
 resource "local_file" "hosts_ini" {
-  content = templatefile("${path.module}/../hosts_ini.tpl",
-    {
-      redpanda_public_ips        = google_compute_instance.redpanda[*].network_interface.0.access_config.0.nat_ip
-      redpanda_private_ips       = google_compute_instance.redpanda[*].network_interface.0.network_ip
-      clients_public_ips         = google_compute_instance.client[*].network_interface.0.access_config.0.nat_ip
-      clients_private_ips        = google_compute_instance.client[*].network_interface.0.network_ip
-      control_public_ips         = google_compute_instance.client[*].network_interface.0.access_config.0.nat_ip
-      control_private_ips        = google_compute_instance.client[*].network_interface.0.network_ip
-      prometheus_host_public_ips = google_compute_instance.monitor[*].network_interface.0.access_config.0.nat_ip
-      prometheus_host_private_ips= google_compute_instance.monitor[*].network_interface.0.network_ip
-      ssh_user                   = var.ssh_user
-      instance_type              = var.machine_type
-    }
-  )
+  content = templatefile("${path.module}/../hosts_ini.tpl", {
+    redpanda_public_ips         = google_compute_instance.redpanda[*].network_interface.0.access_config.0.nat_ip
+    redpanda_private_ips        = google_compute_instance.redpanda[*].network_interface.0.network_ip
+    clients_public_ips          = google_compute_instance.client[*].network_interface.0.access_config.0.nat_ip
+    clients_private_ips         = google_compute_instance.client[*].network_interface.0.network_ip
+    control_public_ips          = google_compute_instance.client[*].network_interface.0.access_config.0.nat_ip
+    control_private_ips         = google_compute_instance.client[*].network_interface.0.network_ip
+    prometheus_host_public_ips  = google_compute_instance.monitor[*].network_interface.0.access_config.0.nat_ip
+    prometheus_host_private_ips = google_compute_instance.monitor[*].network_interface.0.network_ip
+    ssh_user                    = var.ssh_user
+    instance_type               = var.instance_types["redpanda"]
+  })
   filename = "${path.module}/../hosts.ini"
 }
 
@@ -168,6 +243,10 @@ output "private_ips" {
   value = google_compute_instance.redpanda[*].network_interface.0.network_ip
 }
 
+output "client_ssh_host" {
+  value = google_compute_instance.client[0].network_interface.0.access_config.0.nat_ip
+}
+
 output "ssh_user" {
   value = var.ssh_user
 }
@@ -176,99 +255,97 @@ output "public_key_path" {
   value = var.public_key_path
 }
 
-output "client_ssh_host" {
-  value = "${google_compute_instance.client[0].network_interface.0.access_config.0.nat_ip}"
-}
-
-variable "region" {
-  default = "us-west2"
-}
-
-variable "availability_zone" {
-  description = "The zone where the cluster will be deployed [a,b,...]"
-  default     = ["a"]
-  type        = list(string)
-}
-
-variable "instance_group_name" {
-  description = "The name of the GCP instance group"
-  default     = "redpanda-group"
-}
-
-variable "subnet" {
-  description = "The name of the existing subnet where the machines will be deployed"
+output "benchmark_network_name" {
+  value = google_compute_network.benchmark.name
 }
 
 variable "project_name" {
-  description = "The project name on GCP."
+  description = "The GCP project ID."
 }
 
-variable "nodes" {
-  description = "The number of nodes to deploy."
-  type        = number
-  default     = "3"
+variable "region" {
+  default = "us-central1"
+}
+
+variable "availability_zone" {
+  description = "Zones where the cluster will be deployed, e.g. [\"us-central1-a\", \"us-central1-b\"]"
+  default     = ["us-central1-a"]
+  type        = list(string)
+}
+
+variable "benchmark_subnet_cidr" {
+  description = "CIDR block for the benchmark subnet"
+  default     = "10.0.0.0/24"
 }
 
 variable "ha" {
-  description = "Whether to use placement groups to create an HA topology"
+  description = "Whether to use placement groups to create an HA topology."
   type        = bool
   default     = false
 }
 
-variable "client_nodes" {
-  description = "The number of clients to deploy."
-  type        = number
-  default     = "4"
-}
-
 variable "disks" {
-  description = "The number of local disks on each machine."
+  description = "The number of local NVMe disks on each Redpanda node."
   type        = number
   default     = 1
 }
 
 variable "client_disks" {
-  description = "The number of local disks on each machine."
+  description = "The number of local NVMe disks on each client node."
   type        = number
   default     = 2
 }
 
 variable "image" {
-  # See https://cloud.google.com/compute/docs/images#os-compute-support
-  # for an updated list.
-  default = "ubuntu-os-cloud/ubuntu-2204-lts"
+  description = "The GCP OS image for all instances. See https://cloud.google.com/compute/docs/images#os-compute-support"
+  default     = "ubuntu-os-cloud/ubuntu-2204-lts"
 }
 
-variable machine_type {
-  # List of available machines per region/ zone:
-  # https://cloud.google.com/compute/docs/regions-zones#available
-  default = "n2-standard-8"
+variable "instance_types" {
+  description = "Machine type for each node role. Must support local NVMe SSDs (e.g. n2d, c2, c3 series)."
+  type        = map(string)
+  default = {
+    "redpanda"   = "n2d-standard-8"
+    "client"     = "n2d-standard-16"
+    "prometheus" = "n2d-standard-4"
+  }
 }
 
-variable monitor_machine_type {
-  default = "n2-standard-4"
-}
-
-variable client_machine_type {
-  default = "n2-standard-16"
+variable "num_instances" {
+  description = "Number of instances per node role."
+  type        = map(number)
+  default = {
+    "redpanda"   = 3
+    "client"     = 4
+    "prometheus" = 1
+  }
 }
 
 variable "public_key_path" {
-  description = "The ssh key."
+  description = "Path to the SSH public key file."
 }
 
 variable "ssh_user" {
-  description = "The ssh user. Must match the one in the public ssh key's comments."
-}
-
-variable "enable_monitoring" {
-  default = "yes"
+  description = "SSH username."
+  default     = "ubuntu"
 }
 
 variable "labels" {
-  description = "passthrough of GCP labels"
-  default     = {
+  description = "GCP labels to apply to all instances."
+  default = {
     "purpose"      = "redpanda-cluster"
     "created-with" = "terraform"
   }
+}
+
+variable "byoc_vpc_name" {
+  description = "Name of the Redpanda BYOC VPC to peer with. Set to null to skip peering. Note: GCP peering automatically exchanges subnet routes — no CIDR needed unlike AWS."
+  default     = null
+  type        = string
+}
+
+variable "gcp_project" {
+  description = "GCP project ID where the BYOC VPC lives. Defaults to project_name if null."
+  default     = null
+  type        = string
 }

--- a/driver-redpanda/deploy/gcp/terraform.tfvars.example
+++ b/driver-redpanda/deploy/gcp/terraform.tfvars.example
@@ -1,0 +1,26 @@
+public_key_path = "~/.ssh/redpanda_gcp.pub"
+
+region            = "us-central1"
+availability_zone = ["us-central1-a"]
+
+# GCP VPC networks have no CIDR — only subnets do. No benchmark_vpc_cidr needed.
+benchmark_subnet_cidr = "10.0.0.0/24"
+
+# Optional network peering to existing Redpanda BYOC VPC
+# Note: GCP peering automatically exchanges subnet routes — no CIDR required unlike AWS
+byoc_vpc_name = null  # example: "redpanda-network-abcd1234"  //use null if no peering is required
+gcp_project   = null  # example: "my-byoc-gcp-project"        //use null if no peering is required
+
+instance_types = {
+  "redpanda"   = "n2d-standard-8"
+  "client"     = "n2d-standard-16"
+  "prometheus" = "n2d-standard-4"
+}
+
+# client instances may need to be larger than redpanda broker count
+# to provide enough message volume for testing
+num_instances = {
+  "redpanda"   = 3
+  "client"     = 4
+  "prometheus" = 1
+}


### PR DESCRIPTION
## Summary

- Adds `driver-redpanda/deploy/gcp/` with self-contained GCP Terraform configuration
- Provisions VPC, subnet, firewall rules, and compute instances (Redpanda brokers, clients, Prometheus)
- Supports optional VPC peering to an existing Redpanda BYOC network
- Includes `terraform.tfvars.example` and README with usage instructions for both standalone and BYOC deployments
- No changes to existing AWS infrastructure

## Test plan

- [x] `terraform init && terraform apply` provisions all instances cleanly
- [x] `ansible-playbook` deploys successfully against fresh VMs
- [x] Benchmark run completes against BYOC cluster
- [x] `terraform destroy` tears down cleanly